### PR TITLE
Check if firewalld is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,10 @@
 # This role installs RKE2 on control plane
 # nodes and on worker nodes that are
 # RHEL/CentOS based.
+# TODO: Add Ubuntu 18/20 support
+
+- name: Populate service facts
+  service_facts:
 
 # Checks if Red Hat system
 - name: REQUIRES YUM based system
@@ -24,6 +28,8 @@
     name: firewalld
     state: stopped
     enabled: no
+  become: yes
+  when: ansible_facts.services["firewalld.service"] is defined
 
 # CIS mode
 - import_tasks: cis-profile.yml


### PR DESCRIPTION
### Proposed changes
This change ensures that firewalld is actually installed before attempting to disable it.
```yaml
# Disable Firewalld
# We recommend disabling firewalld. For Kubernetes 1.19, firewalld must be turned off.
- name: disable FIREWALLD
  ansible.builtin.systemd:
    name: firewalld
    state: stopped
    enabled: no
  become: yes
  when: ansible_facts.services["firewalld.service"] is defined
```
