### PR TITLE
Ansible lint now runs without failures

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,53 +1,19 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  role_name: rke2
+  author: rancherfederal
+  description: This installs RKE Government
+  company: Rancher Federal
 
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: MIT
 
   min_ansible_version: 2.9
 
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
+  platforms:
+  - name: EL
+    versions:
+    - 7
+    - 9
 
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
-  galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+  galaxy_tags: ["rancher", "rke2", "rke", "kubernetes", "k8s"]
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
-  

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -48,4 +48,3 @@
     state: directory
     recurse: yes
   when: not rke2_agent_images.stat.exists
-


### PR DESCRIPTION
### Proposed changes
`ansible-lint` checks playbooks for practices and behaviour that could potentially be improved. This role should conform to as many "best practices" as possible and ansible-lint helps this role get there.