### PR TITLE
feat: skips agent section if those hosts are commented out

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,7 @@
   become: yes
   roles:
     - role: agent
+      when: groups["agent"] is defined
 
 - hosts: server[1:]
   become: yes


### PR DESCRIPTION
### Proposed changes
This verifies that there is an `[agent]` section in the playbook before running the agent roles.