### PR TITLE
fix: Removes 'schedule:' bit from  .github/workflows/ci.yml

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 exclude_paths:
 - .github/
 - molecule/
+- .ansible-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ name: CI
 on:
   pull_request:
   push:
-  schedule:
-    - cron: "0 2 * * *"
 
 jobs:
 


### PR DESCRIPTION
### Proposed changes
This removed the cron job in the `schedule:` section of [.github/workflows/ci.yml](.github/workflows/ci.yml).

This fixes #25 
