### PR TITLE
feat: If images and tarball are provided the play will use them instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .cache/
 
 venv/
+
+test_inventory**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See the [docs](https://docs.rke2.io/) more information about [RKE Government](ht
 
 Platforms
 ---------
-The RKE2 Ansible role only supports CentOS and Red Hat, but will eventually support all [RKE2 Supported Operating Systems](https://docs.rke2.io/install/requirements/#operating-systems)
+The RKE2 Ansible playbook supports all [RKE2 Supported Operating Systems](https://docs.rke2.io/install/requirements/#operating-systems)
 
 Supported Operating Systems:
 ```yaml
@@ -82,6 +82,13 @@ Start provisioning of the cluster using the following command:
 ```bash
 ansible-playbook site.yml -i inventory/my-cluster/hosts.ini
 ```
+
+Tarball Install/Air-Gap Install
+-------------------------------
+Added the neeed files to the [tarball_install](tarball_install]/) directory.
+
+Further info can be found [here](tarball_install/README.md)
+
 
 Kubeconfig
 ----------

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,4 @@ become = True
 host_key_checking = False
 deprecation_warnings = False
 callback_whitelist = profile_roles, timer
+display_skipped_hosts = no

--- a/roles/first_server/tasks/main.yml
+++ b/roles/first_server/tasks/main.yml
@@ -3,17 +3,20 @@
   yum:
     name: rke2-server
     state: latest  # noqa package-latest
-  when: ansible_os_family == 'RedHat'
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - got_rke2_install_ball.stat.exists == false
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
   ansible.builtin.copy:
     src: /usr/local/lib/systemd/system/rke2-server.service
     dest: /etc/systemd/system/rke2-server.service
-    mode: '0755'
+    mode: '0644'
     owner: root
     group: root
     remote_src: yes
-  when: ansible_os_family != 'RedHat'
+  when:
+    - ansible_facts['os_family'] != 'RedHat'
 
 - name: Add write-kubeconfig-mode to config.yaml
   lineinfile:

--- a/roles/first_server/tasks/main.yml
+++ b/roles/first_server/tasks/main.yml
@@ -5,7 +5,7 @@
     state: latest  # noqa package-latest
   when:
     - ansible_facts['os_family'] == 'RedHat'
-    - got_rke2_install_ball.stat.exists
+    - not got_rke2_install_ball.stat.exists
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
   ansible.builtin.copy:

--- a/roles/first_server/tasks/main.yml
+++ b/roles/first_server/tasks/main.yml
@@ -5,7 +5,7 @@
     state: latest  # noqa package-latest
   when:
     - ansible_facts['os_family'] == 'RedHat'
-    - got_rke2_install_ball.stat.exists == false
+    - got_rke2_install_ball.stat.exists
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
   ansible.builtin.copy:

--- a/roles/prereqs/tasks/airgap.yml
+++ b/roles/prereqs/tasks/airgap.yml
@@ -1,5 +1,5 @@
 ---
-- name: Air Gap Setup
+- name: Air-Gap Images
   become: yes
   block:
     - name: Does the airgap images folder exist?
@@ -14,16 +14,37 @@
         recurse: yes
       when: not rke2_agent_images.stat.exists
 
-    - name: WGET | download rke2 images to disk (just to speed up repeated testing)
-      get_url:
-        url: "{{ rke2_image_file_url }}"
-        dest: /opt/rke2-images.linux-amd64.tar.gz
-
-    # copy the container-image tar to the airgap image. we have to do this every time because rke2 will delete the
-    # file on disk after the images are ingested into the containerd store
-    - name: COPY | airgap images to /var/lib/rancher/rke2/agent/images
+    - name: Add images to needed directory if provided
       copy:
-        src: /opt/rke2-images.linux-amd64.tar.gz
-        dest: /var/lib/rancher/rke2/agent/images/rke2-images.linux-amd64.tar.gz
+        src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
+        dest: /var/lib/rancher/rke2/agent/images/
         mode: '0644'
-  when: rke2_airgap_mode | bool
+  when: got_images.stat.exists == true
+
+- name: Air-Gap Tarball Install
+  become: yes
+  block:
+    - name: TARBALL | Make temp dir
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: rke2-install.XXXXXXXXXX
+      register: temp_dir
+
+    - name: Add tarball to needed directory if provided
+      copy:
+        src: "{{ playbook_dir }}/tarball_install/rke2.linux-amd64.tar.gz"
+        dest: "{{ temp_dir.path }}/rke2.linux-amd64.tar.gz"
+        mode: '0644'
+
+    - name: TARBALL | Extract the tarball  # noqa command-instead-of-module
+      command:
+        cmd: tar -xf "{{ temp_dir.path }}/rke2.linux-amd64.tar.gz" -C "{{ tarball_dir }}"
+      changed_when: false
+
+    - name: TARBALL | Remove the temp_dir
+      ansible.builtin.file:
+        path: "{{ temp_dir.path }}"
+        state: absent
+      when: temp_dir.path is defined
+
+  when: got_rke2_install_ball.stat.exists == true

--- a/roles/prereqs/tasks/main.yml
+++ b/roles/prereqs/tasks/main.yml
@@ -1,16 +1,23 @@
 ---
 
-# This role installs the prerequisites of RKE2 on control plane
-# (aka server) nodes and on worker (aka agent)   nodes that are
-# RHEL/CentOS 7/8 based.
-# TODO: Add Ubuntu 18/20 support
-
 - name: Populate service facts
   ansible.builtin.service_facts:
 
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto
+
+- name: Is the images tarball in the tarball_install/ diretory
+  stat:
+    path: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
+  register: got_images
+  delegate_to: 127.0.0.1
+
+- name: Is the install tarball in the tarball_install/ diretory
+  stat:
+    path: "{{ playbook_dir }}/tarball_install/rke2.linux-amd64.tar.gz"
+  register: got_rke2_install_ball
+  delegate_to: 127.0.0.1
 
 - name: RHEL/CentOS requirements
   block:
@@ -24,11 +31,15 @@
 
     # Setup Yum repos
     - include: yum.yml
-  when: ansible_os_family == 'RedHat'
+  when:
+    - ansible_os_family == 'RedHat'
+    - got_rke2_install_ball.stat.exists == false
 
 - name: Tarball install for SLES and Ubuntu
   include: tarball_install.yml
-  when: ansible_os_family != 'RedHat'
+  when:
+    - ansible_facts['os_family'] != 'RedHat'
+    - got_rke2_install_ball.stat.exists == false
 
 # Disable Firewalld
 # We recommend disabling firewalld. For Kubernetes 1.19, firewalld must be turned off.
@@ -43,4 +54,4 @@
 - include: config.yml
 
 - include: airgap.yml
-  when: rke2_airgap_mode | bool
+  when: got_images.stat.exists == true or got_rke2_install_ball.stat.exists == true

--- a/roles/prereqs/tasks/main.yml
+++ b/roles/prereqs/tasks/main.yml
@@ -21,10 +21,6 @@
   delegate_to: 127.0.0.1
   become: no
 
-- name: Debug
-  ansible.builtin.debug:
-    msg: "{{got_rke2_install_ball}}"
-
 - name: RHEL/CentOS requirements
   block:
     # For use with ansible_lsb

--- a/roles/prereqs/tasks/main.yml
+++ b/roles/prereqs/tasks/main.yml
@@ -12,12 +12,18 @@
     path: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
   register: got_images
   delegate_to: 127.0.0.1
+  become: no
 
 - name: Is the install tarball in the tarball_install/ diretory
   stat:
     path: "{{ playbook_dir }}/tarball_install/rke2.linux-amd64.tar.gz"
   register: got_rke2_install_ball
   delegate_to: 127.0.0.1
+  become: no
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: "{{got_rke2_install_ball}}"
 
 - name: RHEL/CentOS requirements
   block:

--- a/tarball_install/README.md
+++ b/tarball_install/README.md
@@ -1,0 +1,32 @@
+
+```
+               ,        ,  _______________________________
+   ,-----------|'------'|  |                             |
+  /.           '-'    |-'  |_____________________________|
+ |/|             |    |
+   |   .________.'----'    _______________________________
+   |  ||        |  ||      |                             |
+   \__|'        \__|'      |_____________________________|
+
+|‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾|
+|________________________________________________________|
+
+|‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾|
+|________________________________________________________|
+```
+# Air-Gap Install
+
+RKE2 can be installed in an air-gapped environment with two different methods. You can either deploy via the rke2-airgap-images tarball release artifact, or by using a private registry.
+
+All files mentioned in the steps can be obtained from the assets of the desired released rke2 version [here](https://github.com/rancher/rke2/releases).
+
+If running on an SELinux enforcing air-gapped node, you must first install the necessary SELinux policy RPM before performing these steps. See our [RPM Documentation](https://github.com/rancher/rke2#rpm-repositories) to determine what you need.
+
+# Tarball Method
+This ansible playbook will detect if the `rke2-images.linux-amd64.tar.zst` and `rke2.linux-amd64.tar.gz` files are in the tarball_install/ directory. If the files are in the directory then the install process will skip both the yum install and the need to download the tarball.
+
+## Images Install
+If the `rke2-images.linux-amd64.tar.zst` file is found in the tarbarll_install/ directory then this playbook will use those images and not docker.io or a private registry.
+
+## Tarball Install
+If the `rke2.linux-amd64.tar.gz` file is found in the tarball_install/ directory then this playbook will install RKE2 using that version. This will use the default docker.io registry unless the images tarball is present or unless the `system-default-registry` variable is set.


### PR DESCRIPTION
### Proposed changes
When the user of this playbook does not have access to the internet and on an air gap network they can now use this playbook to still install RKE2.  
The user merely needs to provide the  `rke2-images.linux-amd64.tar.zst` and/or `rke2.linux-amd64.tar.gz` tarballs in the `tarball_install` directory and this playbook will use them accordingly.  If an images tarball is not provided then RKE2 will use the system default image repository to pull images.
