### PR TITLE
Reboot when hardening

### DIFF
--- a/roles/rke2_common/tasks/cis-hardening.yml
+++ b/roles/rke2_common/tasks/cis-hardening.yml
@@ -40,16 +40,11 @@
       register: sysctl_operation_tarball
       when: ansible_facts['os_family'] != 'RedHat' or got_rke2_install_ball.stat.exists
 
-    - debug: msg={{ sysctl_operation_yum }}
-    - debug: msg={{ sysctl_operation_tarball }}
-
     - name: restart systemd-sysctl
       service:
         state: restarted
         name: systemd-sysctl
       when: sysctl_operation_yum.changed or sysctl_operation_tarball.changed
-
-    - pause:
 
     - name: Reboot the machine (Wait for 5 min)
       reboot:

--- a/roles/rke2_common/tasks/cis-hardening.yml
+++ b/roles/rke2_common/tasks/cis-hardening.yml
@@ -27,7 +27,7 @@
         src: /usr/share/rke2/rke2-cis-sysctl.conf
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: yes
-      register: sysctl_operation
+      register: sysctl_operation_yum
       when:
         - ansible_os_family == 'RedHat'
         - not got_rke2_install_ball.stat.exists
@@ -37,11 +37,21 @@
         src: /usr/local/share/rke2/rke2-cis-sysctl.conf
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: yes
-      register: sysctl_operation
+      register: sysctl_operation_tarball
       when: ansible_facts['os_family'] != 'RedHat' or got_rke2_install_ball.stat.exists
+
+    - debug: msg={{ sysctl_operation_yum }}
+    - debug: msg={{ sysctl_operation_tarball }}
 
     - name: restart systemd-sysctl
       service:
         state: restarted
         name: systemd-sysctl
-      when: sysctl_operation.changed
+      when: sysctl_operation_yum.changed or sysctl_operation_tarball.changed
+
+    - pause:
+
+    - name: Reboot the machine (Wait for 5 min)
+      reboot:
+        reboot_timeout: 300
+      when: sysctl_operation_yum.changed or sysctl_operation_tarball.changed


### PR DESCRIPTION
### Proposed changes
The machines need to be rebooted when the change to the kernel files is instituted. This also ensures that there are two different variables registered for the two different tasks.