### PR TITLE
fix: awk is in a different location for ubuntu

### DIFF
--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -43,7 +43,7 @@
       delegate_to: 127.0.0.1
 
     - name: Set Maj.Min version
-      shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /bin/awk -F'.' '{ print $1"."$2 }' | sed "s|^v||g"
+      shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | awk -F'.' '{ print $1"."$2 }' | sed "s|^v||g"
       register: rke2_version
       changed_when: false
       args:


### PR DESCRIPTION
### Proposed changes
Removing the full path to `awk` in tarball_install.yml because on a Ubuntu system its located in `/usr/bin/awk`. Instead of writing more logic its easier to remove the full path.  Its still in the `$PATH` so there is no need for it to be full.
