### PR TITLE
Add rke2 env file handling

### DIFF
--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -3,3 +3,4 @@ tarball_dir: "/usr/local"
 rke2_channel: stable
 audit_policy_config_file_path: ""
 registry_config_file_path: ""
+rke2_env_file_path: ""

--- a/roles/rke2_common/tasks/add-rke2-env.yml
+++ b/roles/rke2_common/tasks/add-rke2-env.yml
@@ -1,0 +1,8 @@
+---
+- name: Add rke2 env file
+  copy:
+    src: "{{ rke2_env_file_path }}"
+    dest: "/etc/default/rke2-server"
+    mode: '0644'
+    owner: root
+    group: root

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -60,4 +60,7 @@
 - include: add-registry-config.yml
   when: registry_config_file_path | length > 0
 
+- include: add-rke2-env.yml
+  when: rke2_env_file_path | length > 0
+
 - include: airgap.yml


### PR DESCRIPTION
### Proposed changes
In order to handle rke2 environment variable (mainly for containerd proxy configuration or other)

document
-   add add-rke2-env role called by main if rke2_env_file_path is not empty

rke2-env file should look like this:

http_proxy=http://192.168.1.1:3128
https_proxy=http://192.168.1.1:3128
no_proxy=192.168.0.0/16,localhost,127.0.0.1
HTTPS_PROXY=http://192.168.1.1:3128
HTTP_PROXY=http://192.168.1.1:3128
NO_PROXY=192.168.0.0/16,localhost,127.0.0.1
