### PR TITLE
Add specific node label

### DIFF
--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -1,12 +1,12 @@
 [rke2_servers]
-; host0
-; host1
-; host2
+; host0 node_label_provider="aws"
+; host1 node_label_provider="aws"
+; host2 node_label_provider="aws"
 
 [rke2_agents]
-; host4
-; host5
-; host6
+; host4 node_label_provider="openstack"
+; host5 node_label_provider="openstack"
+; host6 node_label_provider="openstack"
 
 [rke2_cluster:children]
 rke2_servers

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -66,4 +66,4 @@
     path: /etc/rancher/rke2/config.yaml
     line: "node-label: {{ item [11:] }}={{ lookup('vars', item) }}"
   with_items:
-  - "{{ specific_node_labels | default([]) }}"
+    - "{{ specific_node_labels | default([]) }}"

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -56,3 +56,14 @@
     line: "node-label: {{ item }}"
   with_items:
     - "{{ rke2_node_labels | default([]) }}"
+
+- name: Get specific node label key
+  set_fact:
+    specific_node_labels: "{{ hostvars[inventory_hostname] | select('match','node_label_.*') | list }}"
+
+- name: Add specific node-labels
+  lineinfile:
+    path: /etc/rancher/rke2/config.yaml
+    line: "node-label: {{ item [11:] }}={{ lookup('vars', item) }}"
+  with_items:
+  - "{{ specific_node_labels | default([]) }}"


### PR DESCRIPTION
### Proposed changes
In order to categorize nodes, I add the capability to set specific node label from inventory file with host variable beginning with node_label_xxxx.

### Checklist
tested with no node_label_XXX variable and some of them.
Add example in host.ini file