### PR TITLE
fix: RKE2 offers images in tar.gz and tar.zst format

### DIFF
--- a/roles/rke2_common/tasks/airgap.yml
+++ b/roles/rke2_common/tasks/airgap.yml
@@ -1,7 +1,7 @@
 ---
 - name: Air-Gap Images
   become: yes
-  when: got_images_gz.stat.exists == true or got_images_zst.stat.exists == true
+  when: got_images_gz.stat.exists or got_images_zst.stat.exists
   block:
     - name: Does the airgap images folder exist?
       stat:
@@ -20,14 +20,14 @@
         src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.gz"
         dest: /var/lib/rancher/rke2/agent/images/
         mode: '0644'
-      when: got_images_gz.stat.exists == true
+      when: got_images_gz.stat.exists
 
     - name: Add images tar.zst to needed directory if provided
       copy:
         src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
         dest: /var/lib/rancher/rke2/agent/images/
         mode: '0644'
-      when: got_images_zst.stat.exists == true
+      when: got_images_zst.stat.exists
 
 - name: Air-Gap Tarball Install
   become: yes

--- a/roles/rke2_common/tasks/airgap.yml
+++ b/roles/rke2_common/tasks/airgap.yml
@@ -1,7 +1,7 @@
 ---
 - name: Air-Gap Images
   become: yes
-  when: got_images.stat.exists == true
+  when: got_images_gz.stat.exists == true or got_images_zst.stat.exists == true
   block:
     - name: Does the airgap images folder exist?
       stat:
@@ -15,11 +15,19 @@
         recurse: yes
       when: not rke2_agent_images.stat.exists
 
-    - name: Add images to needed directory if provided
+    - name: Add images tar.gz to needed directory if provided
       copy:
         src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.gz"
         dest: /var/lib/rancher/rke2/agent/images/
         mode: '0644'
+      when: got_images_gz.stat.exists == true
+
+    - name: Add images tar.zst to needed directory if provided
+      copy:
+        src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
+        dest: /var/lib/rancher/rke2/agent/images/
+        mode: '0644'
+      when: got_images_zst.stat.exists == true
 
 - name: Air-Gap Tarball Install
   become: yes

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -7,10 +7,17 @@
   ansible.builtin.package_facts:
     manager: auto
 
-- name: Is the images tarball in the tarball_install/ diretory
+- name: Is the images tar.gz in the tarball_install/ diretory
   stat:
     path: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.gz"
-  register: got_images
+  register: got_images_gz
+  delegate_to: 127.0.0.1
+  become: no
+
+- name: Is the images tar.zst in the tarball_install/ diretory
+  stat:
+    path: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
+  register: got_images_zst
   delegate_to: 127.0.0.1
   become: no
 

--- a/tarball_install/README.md
+++ b/tarball_install/README.md
@@ -26,7 +26,7 @@ If running on an SELinux enforcing air-gapped node, you must first install the n
 This ansible playbook will detect if the `rke2-images.linux-amd64.tar.zst` and `rke2.linux-amd64.tar.gz` files are in the tarball_install/ directory. If the files are in the directory then the install process will skip both the yum install and the need to download the tarball.
 
 ## Images Install
-If the `rke2-images.linux-amd64.tar.zst` file is found in the tarbarll_install/ directory then this playbook will use those images and not docker.io or a private registry.
+If either the `rke2-images.linux-amd64.tar.zst` or `rke2-images.linux-amd64.tar.gz` files are found in the tarbarll_install/ directory then this playbook will use the images inside the tarball and not docker.io or a private registry.
 
 ## Tarball Install
 If the `rke2.linux-amd64.tar.gz` file is found in the tarball_install/ directory then this playbook will install RKE2 using that version. This will use the default docker.io registry unless the images tarball is present or unless the `system-default-registry` variable is set.


### PR DESCRIPTION
### Proposed changes
The release assets for RKE2 offers the images used in airgap installs in both `tar.gz` and `tar.zst`.  The playbook now checks to see if either of those files exist.


This fixes #41