### PR TITLE
Added NetworkManager fix. Fixes #48

### DIFF
--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -59,6 +59,9 @@
     enabled: no
   when: ansible_facts.services["firewalld.service"] is defined
 
+- name: NetworkManager fixes
+  include: networkmanager-fix.yml
+
 - include: config.yml
 
 - include: add-audit-policy-config.yml

--- a/roles/rke2_common/tasks/networkmanager-fix.yml
+++ b/roles/rke2_common/tasks/networkmanager-fix.yml
@@ -1,0 +1,42 @@
+---
+
+# This fixes known issue with NetworkManager
+# https://docs.rke2.io/known_issues/#networkmanager
+
+
+- name: Add NetworkManager fix to rke2-canal.conf
+  blockinfile:
+    path: /etc/NetworkManager/conf.d/rke2-canal.conf
+    block: |
+      [keyfile]
+      unmanaged-devices=interface-name:cali*;interface-name:flannel*
+    create: yes
+  when: ansible_facts.services["NetworkManager.service"] is defined
+
+- name: Does rke2-canal.conf exist
+  stat:
+    path: /etc/NetworkManager/conf.d/rke2-canal.conf
+  register: rke2-canal-file
+
+- name: Set rke2-canal.conf file permissions
+  ansible.builtin.file:
+    path: /etc/NetworkManager/conf.d/rke2-canal.conf
+    mode: '0600'
+    owner: root
+    group: root
+  when: rke2-canal-file.stat.exists
+
+- name: Disable service nm-cloud-setup
+  ansible.builtin.systemd:
+    name: nm-cloud-setup.service
+    enabled: no
+    state: stopped
+  when: ansible_facts.services["nm-cloud-setup.service"] is defined
+
+
+- name: Disable nm-cloud-setup.timer unit
+  ansible.builtin.systemd:
+    name: nm-cloud-setup.timer
+    state: stopped
+    enabled: no
+  when: ansible_facts.services["nm-cloud-setup.service"] is defined


### PR DESCRIPTION
### Proposed changes
This PR adds the rke2-canal.conf file and its contents if NetworkManager is installed.  This follows the instructions provided by the RKE2 docs:
https://docs.rke2.io/known_issues/#networkmanager

This fixes #48 