### PR TITLE
Fix ansible 2.9 compatibility and manifest config for addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Server and agent nodes must have passwordless SSH access
 Usage
 -----
 
-First create a new directory based on the `sample` directory within the `inventory` directory:
+This playbook requires ansible.utils to run properly. Please see https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-a-collection-from-galaxy for more information about how to install this.
+
+```
+ansible-galaxy collection install -r requirements.yml
+```
+
+Create a new directory based on the `sample` directory within the `inventory` directory:
 
 ```bash
 cp -R inventory/sample inventory/my-cluster

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.utils

--- a/roles/rke2_agent/tasks/main.yml
+++ b/roles/rke2_agent/tasks/main.yml
@@ -16,7 +16,7 @@
     line: "token: {{ hostvars[groups['rke2_servers'][0]].rke2_config_token }}"
 
 - name: Start rke2-agent
-  ansible.builtin.systemd:
+  systemd:
     name: rke2-agent.service
     state: started
     enabled: yes

--- a/roles/rke2_common/tasks/add-audit-policy-config.yml
+++ b/roles/rke2_common/tasks/add-audit-policy-config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create the /etc/rancher/rke2 config dir
-  ansible.builtin.file:
+  file:
     path: /etc/rancher/rke2
     state: directory
     recurse: yes

--- a/roles/rke2_common/tasks/add-registry-config.yml
+++ b/roles/rke2_common/tasks/add-registry-config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create the /etc/rancher/rke2 config dir
-  ansible.builtin.file:
+  file:
     path: /etc/rancher/rke2
     state: directory
     recurse: yes

--- a/roles/rke2_common/tasks/cis-hardening.yml
+++ b/roles/rke2_common/tasks/cis-hardening.yml
@@ -5,19 +5,19 @@
   block:
 
     - name: Create etcd group
-      ansible.builtin.group:
+      group:
         name: etcd
         state: present
 
     - name: Create etcd user
-      ansible.builtin.user:
+      user:
         name: etcd
         comment: etcd user
         shell: /bin/nologin
         group: etcd
 
     - name: Copy systemctl file for kernel hardening for yum installs
-      ansible.builtin.copy:
+      copy:
         src: /usr/share/rke2/rke2-cis-sysctl.conf
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: yes
@@ -28,7 +28,7 @@
         - not rke2_binary_tarball_check.stat.exists
 
     - name: Copy systemctl file for kernel hardening for non-yum installs
-      ansible.builtin.copy:
+      copy:
         src: /usr/local/share/rke2/rke2-cis-sysctl.conf
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: yes

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: Create the /etc/rancher/rke2 config dir
-  ansible.builtin.file:
+  file:
     path: /etc/rancher/rke2
     state: directory
     recurse: yes
 
 - name: create the /etc/rancher/rke2/config.yaml file
-  ansible.builtin.file:
+  file:
     path: /etc/rancher/rke2/config.yaml
     state: touch
     mode: "0640"
@@ -17,11 +17,11 @@
 # --node-label value                     (agent/node) Registering and starting kubelet with set of labels
 # --node-taint value                     (agent/node) Registering kubelet with set of taints
 - name: Combine rke2_config node labels and hostvar node labels
-  ansible.builtin.set_fact:
+  set_fact:
     all_node_labels: "{{ rke2_config['node-label'] | default([]) }} + {{ node_labels | default([]) }}"
 
 - name: Combine rke2_config node taints and hostvar node taints
-  ansible.builtin.set_fact:
+  set_fact:
     all_node_taints: "{{ rke2_config['node-taint'] | default([]) }} + {{ node_taints | default([]) }}"
 
 - name: Add node labels to rke2_config

--- a/roles/rke2_common/tasks/iptables_rules.yml
+++ b/roles/rke2_common/tasks/iptables_rules.yml
@@ -77,28 +77,28 @@
     jump: ACCEPT
 
 - name: "Allow cluster-cidr forward"
-  ansible.builtin.iptables:
+  iptables:
     action: insert
     chain: FORWARD
     source: '{{ rke2_config["cluster-cidr"] | default("10.42.0.0/16") | string }}'
     jump: ACCEPT
 
 - name: "Allow cluster-cidr forward"
-  ansible.builtin.iptables:
+  iptables:
     action: insert
     chain: FORWARD
     destination: '{{ rke2_config["cluster-cidr"] | default("10.42.0.0/16") | string }}'
     jump: ACCEPT
 
 - name: "Allow cluster-cidr input"
-  ansible.builtin.iptables:
+  iptables:
     action: insert
     chain: INPUT
     source: '{{ rke2_config["cluster-cidr"] | default("10.42.0.0/16") | string }}'
     jump: ACCEPT
 
 - name: "Allow cluster-cidr input"
-  ansible.builtin.iptables:
+  iptables:
     action: insert
     chain: INPUT
     destination: '{{ rke2_config["cluster-cidr"] | default("10.42.0.0/16") | string }}'

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -59,7 +59,6 @@
 - include: add-audit-policy-config.yml
   when:
     - audit_policy_config_file_path | length > 0
-    - inventory_hostname in groups['rke2_servers']
 
 - include: add-registry-config.yml
   when: registry_config_file_path | length > 0

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Populate service facts
-  service_facts:
+  service_facts: {}
 
 - name: Gather the package facts
   package_facts:
@@ -56,12 +56,6 @@
 - include: add-audit-policy-config.yml
   when:
     - audit_policy_config_file_path | length > 0
-    - inventory_hostname in groups['rke2_servers']
-
-- include: add-manifest-addons.yml
-  when:
-    - manifest_config_file_path is defined
-    - manifest_config_file_path | length > 0
     - inventory_hostname in groups['rke2_servers']
 
 - include: add-registry-config.yml

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -20,8 +20,8 @@
   include: tarball_install.yml
   when:
     - |-
-      (ansible_facts['os_family'] != 'RedHat' and 
-      ansible_facts['os_family'] != 'Rocky') or 
+      (ansible_facts['os_family'] != 'RedHat' and
+      ansible_facts['os_family'] != 'Rocky') or
       rke2_binary_tarball_check.stat.exists == true
 
 - name: RHEL/CentOS Installation

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Populate service facts
-  ansible.builtin.service_facts:
+  service_facts:
 
 - name: Gather the package facts
-  ansible.builtin.package_facts:
+  package_facts:
     manager: auto
 
 - include: images_tarball_install.yml
@@ -24,10 +24,10 @@
 - name: RHEL/CentOS Installation
   block:
     - name: Install redhat-lsb-core
-      ansible.builtin.yum: name=redhat-lsb-core state=present
+      yum: name=redhat-lsb-core state=present
       when: "'redhat-lsb-core' not in ansible_facts.packages"
     - name: Reread ansible_lsb facts
-      ansible.builtin.setup: filter=ansible_lsb*
+      setup: filter=ansible_lsb*
       when: "'redhat-lsb-core' not in ansible_facts.packages"
     - include: rpm_install.yml
   when:
@@ -37,7 +37,7 @@
 # Disable Firewalld
 # We recommend disabling firewalld. For Kubernetes 1.19+, firewalld must be turned off.
 - name: disable FIREWALLD
-  ansible.builtin.systemd:
+  systemd:
     name: firewalld
     state: stopped
     enabled: no
@@ -54,7 +54,15 @@
     - add_iptables_rules is true
 
 - include: add-audit-policy-config.yml
-  when: audit_policy_config_file_path | length > 0
+  when:
+    - audit_policy_config_file_path | length > 0
+    - inventory_hostname in groups['rke2_servers']
+
+- include: add-manifest-addons.yml
+  when:
+    - manifest_config_file_path is defined
+    - manifest_config_file_path | length > 0
+    - inventory_hostname in groups['rke2_servers']
 
 - include: add-registry-config.yml
   when: registry_config_file_path | length > 0

--- a/roles/rke2_common/tasks/network_manager_fix.yaml
+++ b/roles/rke2_common/tasks/network_manager_fix.yaml
@@ -19,7 +19,7 @@
   register: rke2_canal_file
 
 - name: Set rke2-canal.conf file permissions
-  ansible.builtin.file:
+  file:
     path: /etc/NetworkManager/conf.d/rke2-canal.conf
     mode: '0600'
     owner: root
@@ -27,14 +27,14 @@
   when: rke2_canal_file.stat.exists
 
 - name: Disable service nm-cloud-setup
-  ansible.builtin.systemd:
+  systemd:
     name: nm-cloud-setup.service
     enabled: no
     state: stopped
   when: ansible_facts.services["nm-cloud-setup.service"] is defined
 
 - name: Disable nm-cloud-setup.timer unit
-  ansible.builtin.systemd:
+  systemd:
     name: nm-cloud-setup.timer
     state: stopped
     enabled: no

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -45,7 +45,7 @@
 
 # Add RKE2 Common repo if it doesn't exist
 - name: add the rke2-common repo RHEL/CentOS 7
-  ansible.builtin.yum_repository:
+  yum_repository:
     name: rke2-common
     description: Rancher RKE2 Common Latest
     baseurl: "https://rpm.rancher.io/rke2/latest/common/centos/7/noarch"
@@ -55,7 +55,7 @@
   when: not stat_rke2_common.stat.exists and ansible_lsb.major_release == '7'
 
 - name: add the rke2-common repo RHEL/CentOS 8
-  ansible.builtin.yum_repository:
+  yum_repository:
     name: rke2-common
     description: Rancher RKE2 Common Latest
     baseurl: "https://rpm.rancher.io/rke2/latest/common/centos/8/noarch"
@@ -72,7 +72,7 @@
 
 # Add RKE2 versioned repo if it doesn't exist
 - name: Add the rke2 versioned repo CentOS/RHEL 7
-  ansible.builtin.yum_repository:
+  yum_repository:
     name: "rke2-v{{ rke2_version.stdout }}"  # noqa var-spacing
     description: Rancher RKE2 Version
     baseurl: "https://rpm.rancher.io/rke2/latest/{{ rke2_version.stdout }}/centos/7/x86_64"
@@ -82,7 +82,7 @@
   when: (not stat_rke2_versioned_repo.stat.exists) and (ansible_lsb.major_release == '7')
 
 - name: add the rke2 versioned repo CentOS/RHEL 8
-  ansible.builtin.yum_repository:
+  yum_repository:
     name: "rke2-v{{ rke2_version.stdout }}"  # noqa var-spacing
     description: Rancher RKE2 Version
     baseurl: "https://rpm.rancher.io/rke2/latest/{{ rke2_version.stdout }}/centos/8/x86_64"

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -12,7 +12,7 @@
 # }
 
 - name: TARBALL | Make temp dir
-  ansible.builtin.tempfile:
+  tempfile:
     state: directory
     suffix: rke2-install.XXXXXXXXXX
   register: temp_dir
@@ -99,13 +99,13 @@
   changed_when: false
 
 - name: TARBALL | Remove the temp_dir
-  ansible.builtin.file:
+  file:
     path: "{{ temp_dir.path }}"
     state: absent
   when: temp_dir.path is defined
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
-  ansible.builtin.copy:
+  copy:
     src: /usr/local/lib/systemd/system/rke2-server.service
     dest: /etc/systemd/system/rke2-server.service
     mode: '0644'
@@ -116,7 +116,7 @@
     - inventory_hostname in groups['rke2_servers']
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
-  ansible.builtin.copy:
+  copy:
     src: /usr/local/lib/systemd/system/rke2-server.env
     dest: /etc/systemd/system/rke2-server.env
     mode: '0644'
@@ -127,7 +127,7 @@
     - inventory_hostname in groups['rke2_servers']
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
-  ansible.builtin.copy:
+  copy:
     src: /usr/local/lib/systemd/system/rke2-agent.service
     dest: /etc/systemd/system/rke2-agent.service
     mode: '0644'
@@ -138,7 +138,7 @@
     - inventory_hostname in groups['rke2_agents']
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
-  ansible.builtin.copy:
+  copy:
     src: /usr/local/lib/systemd/system/rke2-agent.env
     dest: /etc/systemd/system/rke2-agent.env
     mode: '0644'

--- a/roles/rke2_server/tasks/first_server.yml
+++ b/roles/rke2_server/tasks/first_server.yml
@@ -4,7 +4,9 @@
   include_role:
     name: rke2_common
     tasks_from: add-manifest-addons.yml
-  when: manifest_config_file_path is defined
+  when:
+    - manifest_config_file_path is defined
+    - manifest_config_file_path | length > 0
 
 - name: Start rke2-server
   systemd:

--- a/roles/rke2_server/tasks/first_server.yml
+++ b/roles/rke2_server/tasks/first_server.yml
@@ -7,7 +7,7 @@
   when: manifest_config_file_path is defined
 
 - name: Start rke2-server
-  ansible.builtin.systemd:
+  systemd:
     name: rke2-server
     state: started
     enabled: yes
@@ -20,7 +20,7 @@
     timeout: 300
 
 - name: Wait for kubelet process to be present on host
-  ansible.builtin.command: >-
+  command: >-
     ps -C kubelet -F -ww --no-headers
   register: kubelet_check
   until: kubelet_check.rc == 0
@@ -35,7 +35,7 @@
       '\\1') }}"
 
 - name: Wait for node to show Ready status
-  ansible.builtin.command: >-
+  command: >-
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
     --server https://127.0.0.1:6443 get no {{ kubelet_hostname_override_parameter[0] }}
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'

--- a/roles/rke2_server/tasks/other_servers.yml
+++ b/roles/rke2_server/tasks/other_servers.yml
@@ -14,7 +14,7 @@
   throttle: 1
   block:
     - name: Start rke2-server
-      ansible.builtin.systemd:
+      systemd:
         name: rke2-server
         state: started
         enabled: yes
@@ -27,7 +27,7 @@
         timeout: 300
 
     - name: Wait for kubelet process to be present on host
-      ansible.builtin.command: >-
+      command: >-
         ps -C kubelet -F -ww --no-headers
       register: kubelet_check
       until: kubelet_check.rc == 0
@@ -42,7 +42,7 @@
           '\\1') }}"
 
     - name: Wait for node to show Ready status
-      ansible.builtin.command: >-
+      command: >-
         /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
         --server https://127.0.0.1:6443 get no {{ kubelet_hostname_override_parameter[0] }}
         -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'


### PR DESCRIPTION
### Proposed changes
Ansible 2.9 seems to have problems with the `ansible.builtin` notation so I reverted back to the old style of declaring the modules. Also, due to testing in 2.9, we need to manually add the galaxy collection for `ansible.utils`. I added instructions for this. I also realized that the manifest addon task file was not added to the main common task file, so this was added too.


