### PR TITLE
Swap delegate_to with run_once so version determination happens remotely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint ansible
+        run: |
+          pip3 install yamllint ansible-lint ansible
+          ansible-galaxy collection install -r requirements.yml
 
       - name: Version check
         run: |

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -37,7 +37,7 @@
         url: https://update.rke2.io/v1-release/channels/{{ rke2_channel }}
         follow_redirects: all
       register: rke2_version_url
-      delegate_to: 127.0.0.1
+      run_once: yes
 
     - name: Set full version name
       shell: set -o pipefail && echo {{ rke2_version_url.url }} | sed -e 's|.*/||'
@@ -45,7 +45,7 @@
       changed_when: false
       args:
         executable: /bin/bash
-      delegate_to: 127.0.0.1
+      run_once: yes
 
     - name: Set dot version
       shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /usr/bin/cut -d'+' -f1
@@ -53,7 +53,7 @@
       changed_when: false
       args:
         executable: /bin/bash
-      delegate_to: 127.0.0.1
+      run_once: yes
 
     - name: Set Maj.Min version
       shell: >-
@@ -63,7 +63,7 @@
       changed_when: false
       args:
         executable: /bin/bash
-      delegate_to: 127.0.0.1
+      run_once: yes
 
     - name: Describe versions
       debug:


### PR DESCRIPTION
### Proposed changes
Some people have problems in the tarball_install when the sections for determining the latest version run on localhost. I changed this to run_once remotely instead.
