### PR TITLE
fix the hostname determination regex

### DIFF
--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -2,9 +2,9 @@
 ; Optional hostvars that can be pased in to individual nodes include node_ip, node_name, bind_address, advertise_address, node_taints=[], node_labels=[], and node_external_ip
 ; Example:
 [rke2_servers]
-; host0 node_labels='["extraLabel0=true"]' node_ip="10.10.10.10" node_name="customName0" bind_address="10.10.10.10" advertise_adress="10.10.10.10" node_external_ip="52.52.52.52" node_taints='["CriticalAddonsOnly=true:NoSchedule"]'
-; host1 node_labels='["extraLabel1=true"]' node_ip="10.10.10.11" node_name="customName1" node_taints='["CriticalAddonsOnly=true:NoSchedule"]'
-; host2 node_labels='["extraLabel0=true"]' node_ip="10.10.10.12" node_name="customName1" node_taints='["CriticalAddonsOnly=true:NoSchedule"]'
+; host0 node_labels='["extraLabel0=true"]' node_ip="10.10.10.10" node_name="customName0" bind_address="10.10.10.10" advertise_adress="10.10.10.10" node_external_ip="52.52.52.52" node_taints='["CriticalAddonsOnly=true:NoSchedule"]' cloud_provider_name="aws"
+; host1 node_labels='["extraLabel1=true"]' node_ip="10.10.10.11" node_name="customName1" node_taints='["CriticalAddonsOnly=true:NoSchedule"]' cloud_provider_name="aws"
+; host2 node_labels='["extraLabel0=true"]' node_ip="10.10.10.12" node_name="customName1" node_taints='["CriticalAddonsOnly=true:NoSchedule"]' cloud_provider_name="aws"
 
 [rke2_agents]
 ; host4

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -108,6 +108,20 @@
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
 
+# --cloud-provider-name value (agent/node) Cloud provider name
+- name: Add cloud-provider-name to rke2_config
+  ansible.utils.update_fact:
+    updates:
+      - path: rke2_config["cloud-provider-name"]
+        value: "{​​​​​​​​{​​​​​​​​ cloud_provider_name }​​​​​​​​}​​​​​​​​"
+  when: (cloud_provider_name is defined) and (cloud_provider_name|length > 0)
+  register: updated_rke2_config
+
+- name: Update rke2_config to take value of updated_rke2_config
+  set_fact:
+    rke2_config: "{​​​​​​​​{​​​​​​​​ updated_rke2_config.rke2_config }​​​​​​​​}​​​​​​​​"
+  when: updated_rke2_config.changed
+
 - name: Drop in final /etc/rancher/rke2/config.yaml
   copy:
     content: "{{ rke2_config | to_nice_yaml(indent=0) }}"
@@ -115,3 +129,4 @@
     mode: "0640"
     owner: root
     group: root
+

--- a/roles/rke2_server/tasks/first_server.yml
+++ b/roles/rke2_server/tasks/first_server.yml
@@ -33,7 +33,7 @@
 - name: Extract the hostname-override parameter from the kubelet process
   set_fact:
     kubelet_hostname_override_parameter: "{{ kubelet_check.stdout |\
-      regex_search('\\s--hostname-override=((([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
+      regex_search('\\s--hostname-override=((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
       '\\1') }}"
 
 - name: Wait for node to show Ready status


### PR DESCRIPTION
### Proposed changes
Fixed regex used to find the hostname_override parameter.

Also added ability to add a cloud_provider_name="<>" on a node to node basis, although this should probably be set on the group level inside the rke2_config parameter.

@tuckcodes please review/test/merge