### PR TITLE
Begin idempotency

### DIFF
--- a/.github/workflows/vanilla_ubuntu.yml
+++ b/.github/workflows/vanilla_ubuntu.yml
@@ -158,6 +158,7 @@ jobs:
           echo "" >> ansible.cfg
           echo "remote_user=ubuntu" >> ansible.cfg
           echo "private_key_file=.key" >> ansible.cfg
+          cp hosts.ini inventory/ubuntu20/hosts.ini
 
       - name: Run playbook again with added hosts
         run: |

--- a/.github/workflows/vanilla_ubuntu.yml
+++ b/.github/workflows/vanilla_ubuntu.yml
@@ -147,6 +147,7 @@ jobs:
 
       - name: Create new inventory hosts.ini with added hosts
         run: |
+          rm hosts.ini
           touch hosts.ini
           echo "[rke2_servers]" > hosts.ini
           aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=Server" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini

--- a/.github/workflows/vanilla_ubuntu.yml
+++ b/.github/workflows/vanilla_ubuntu.yml
@@ -154,10 +154,6 @@ jobs:
           echo "[rke2_agents]" >> hosts.ini
           aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=Agent" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
           aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=ExtraNode" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
-          echo "" >> ansible.cfg
-          echo "" >> ansible.cfg
-          echo "remote_user=ubuntu" >> ansible.cfg
-          echo "private_key_file=.key" >> ansible.cfg
           cp hosts.ini inventory/ubuntu20/hosts.ini
 
       - name: Run playbook again with added hosts

--- a/.github/workflows/vanilla_ubuntu.yml
+++ b/.github/workflows/vanilla_ubuntu.yml
@@ -131,11 +131,42 @@ jobs:
         run: |
           ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory/ubuntu20/hosts.ini -u ubuntu --verbose --private-key .key site.yml
 
+      - name: Run playbook again for idempotency
+        run: |
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory/ubuntu20/hosts.ini -u ubuntu --verbose --private-key .key site.yml
+
       - name: Run Ansible Tests
         run: |
           ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory/ubuntu20/hosts.ini -u ubuntu --verbose --private-key .key testing.yml
 
       - name: Run Python Tests
+        run: |
+          export DEFAULT_PRIVATE_KEY_FILE=.key
+          pytest --hosts=rke2_servers --ansible-inventory=inventory/ubuntu20/hosts.ini --force-ansible --connection=ansible --sudo testing/basic_server_tests.py
+          pytest --hosts=rke2_agents --ansible-inventory=inventory/ubuntu20/hosts.ini --force-ansible --connection=ansible --sudo testing/basic_agent_tests.py
+
+      - name: Create new inventory hosts.ini with added hosts
+        run: |
+          touch hosts.ini
+          echo "[rke2_servers]" > hosts.ini
+          aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=Server" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
+          echo "[rke2_agents]" >> hosts.ini
+          aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=Agent" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
+          aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=ExtraNode" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
+          echo "" >> ansible.cfg
+          echo "" >> ansible.cfg
+          echo "remote_user=ubuntu" >> ansible.cfg
+          echo "private_key_file=.key" >> ansible.cfg
+
+      - name: Run playbook again with added hosts
+        run: |
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory/ubuntu20/hosts.ini -u ubuntu --verbose --private-key .key site.yml
+
+      - name: Run Ansible Tests with added hosts
+        run: |
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory/ubuntu20/hosts.ini -u ubuntu --verbose --private-key .key testing.yml
+
+      - name: Run Python Tests with added hosts
         run: |
           export DEFAULT_PRIVATE_KEY_FILE=.key
           pytest --hosts=rke2_servers --ansible-inventory=inventory/ubuntu20/hosts.ini --force-ansible --connection=ansible --sudo testing/basic_server_tests.py

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,9 +5,9 @@ inventory  = ./inventory/my-cluster/hosts.ini
 
 remote_tmp = $HOME/.ansible/tmp
 local_tmp  = $HOME/.ansible/tmp
-pipelining = True
+#pipelining = True
 #become = True
 host_key_checking = False
 deprecation_warnings = False
-callback_whitelist = profile_roles, timer
-display_skipped_hosts = no
+#callback_whitelist = profile_roles, timer
+#display_skipped_hosts = no

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,9 +5,9 @@ inventory  = ./inventory/my-cluster/hosts.ini
 
 remote_tmp = $HOME/.ansible/tmp
 local_tmp  = $HOME/.ansible/tmp
-#pipelining = True
+pipelining = True
 #become = True
 host_key_checking = False
 deprecation_warnings = False
-#callback_whitelist = profile_roles, timer
-#display_skipped_hosts = no
+callback_whitelist = profile_roles, timer
+display_skipped_hosts = no

--- a/roles/rke2_agent/tasks/main.yml
+++ b/roles/rke2_agent/tasks/main.yml
@@ -5,15 +5,35 @@
     name: rke2_common
     tasks_from: main
 
-- name: Add server url to config file
-  lineinfile:
-    dest: /etc/rancher/rke2/config.yaml
-    line: "server: https://{{ kubernetes_api_server_host }}:9345"
+- name: Does config file already have server token?  # noqa command-instead-of-shell
+  ansible.builtin.command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
+  register: server_token_check
+  failed_when: server_token_check.rc >= 2
+  changed_when: false
 
 - name: Add token to config.yaml
   lineinfile:
     dest: /etc/rancher/rke2/config.yaml
     line: "token: {{ hostvars[groups['rke2_servers'][0]].rke2_config_token }}"
+    state: present
+    insertbefore: BOF
+  when:
+    - '"token:" not in server_token_check.stdout'
+
+- name: Does config file already have server url?  # noqa command-instead-of-shell
+  ansible.builtin.command: 'grep -i "^server:" /etc/rancher/rke2/config.yaml'
+  register: server_url_check
+  failed_when: server_url_check.rc >= 2
+  changed_when: false
+
+- name: Add server url to config file
+  lineinfile:
+    dest: /etc/rancher/rke2/config.yaml
+    line: "server: https://{{ kubernetes_api_server_host }}:9345"
+    state: present
+    insertbefore: BOF
+  when:
+    - '"server:" not in server_url_check.stdout'
 
 - name: Start rke2-agent
   systemd:

--- a/roles/rke2_agent/vars/main.yml
+++ b/roles/rke2_agent/vars/main.yml
@@ -1,1 +1,2 @@
 ---
+tmp_sha1: 55ca6286e3e4f4fba5d0448333fa99fc5a404a73

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -15,7 +15,7 @@
 - name: Does the /etc/rancher/rke2/config.yaml file exist?
   stat:
     path: /etc/rancher/rke2/config.yaml
-  register: rke2_config
+  register: previous_rke2_config
 
 - name: create the /etc/rancher/rke2/config.yaml file
   file:
@@ -24,17 +24,19 @@
     mode: "0640"
     owner: root
     group: root
-  when: not rke2_config.stat.exists
+  when: not previous_rke2_config.stat.exists
 
 # --node-label value                     (agent/node) Registering and starting kubelet with set of labels
 # --node-taint value                     (agent/node) Registering kubelet with set of taints
 - name: Combine rke2_config node labels and hostvar node labels
   set_fact:
     all_node_labels: "{{ rke2_config['node-label'] | default([]) }} + {{ node_labels | default([]) }}"
+  changed_when: false
 
 - name: Combine rke2_config node taints and hostvar node taints
   set_fact:
     all_node_taints: "{{ rke2_config['node-taint'] | default([]) }} + {{ node_taints | default([]) }}"
+  changed_when: false
 
 - name: Add node labels to rke2_config
   ansible.utils.update_fact:
@@ -44,10 +46,12 @@
       - path: rke2_config["node-taint"]
         value: "{{ all_node_taints }}"
   register: updated_rke2_config
+  changed_when: false
 
 - name: Update rke2_config to take value of updated_rke2_config
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
+  changed_when: false
 
 # --node-ip value, -i value (agent/networking) IPv4/IPv6 addresses to advertise for node
 - name: Add node-ip to rke2_config
@@ -57,11 +61,13 @@
         value: "{{ node_ip }}"
   when: (node_ip is defined) and (node_ip|length > 0)
   register: updated_rke2_config
+  changed_when: false
 
 - name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
+  changed_when: false
 
 # --node-name value (agent/node) Node name [$RKE2_NODE_NAME]
 - name: Add node-name to rke2_config
@@ -71,11 +77,13 @@
         value: "{{ node_name }}"
   when: (node_name is defined) and (node_name|length > 0)
   register: updated_rke2_config
+  changed_when: false
 
 - name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
+  changed_when: false
 
 # --bind-address value (listener) rke2 bind address (default: 0.0.0.0)
 - name: Add bind-address to rke2_config
@@ -85,11 +93,13 @@
         value: "{{ bind_address }}"
   when: (bind_address is defined) and (bind_address|length > 0)
   register: updated_rke2_config
+  changed_when: false
 
 - name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
+  changed_when: false
 
 # --advertise-address value (listener) IPv4 address that apiserver uses
 # to advertise to members of the cluster (default: node-external-ip/node-ip)
@@ -100,11 +110,13 @@
         value: "{{ advertise_address }}"
   when: (advertise_address is defined) and (advertise_address|length > 0)
   register: updated_rke2_config
+  changed_when: false
 
 - name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
+  changed_when: false
 
 # --node-external-ip value (agent/networking) IPv4/IPv6 external IP addresses to advertise for node
 - name: Add node-external-ip to rke2_config
@@ -114,11 +126,13 @@
         value: "{{ node_external_ip }}"
   when: (node_external_ip is defined) and (node_external_ip|length > 0)
   register: updated_rke2_config
+  changed_when: false
 
 - name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
+  changed_when: false
 
 - name: Create tmp config.yaml
   copy:
@@ -127,15 +141,21 @@
     mode: "0600"
     owner: root
     group: root
+  when: previous_rke2_config.stat.exists
+  changed_when: false
 
 - name: Stat tmp config
   stat:
     path: /tmp/ansible-config.txt
   register: tmp_config
+  when: previous_rke2_config.stat.exists
+  changed_when: false
 
 - name: Get cksum of tmp config
   set_fact:
     tmp_sha1: "{{ tmp_config.stat.checksum }}"
+  when: previous_rke2_config.stat.exists
+  changed_when: false
 
 - name: Drop in final /etc/rancher/rke2/config.yaml
   copy:
@@ -144,16 +164,21 @@
     mode: "0640"
     owner: root
     group: root
-  when: tmp_sha1 != rke2_config.stat.checksum
+    backup: yes
+  when: not previous_rke2_config.stat.exists or (tmp_sha1 != previous_rke2_config.stat.checksum)
 
 - name: Restart rke2-server if package installed and config changed
   service:
     state: restarted
     name: rke2-server
-  when: 'rke2-server' in services and tmp_sha1 != rke2_config.stat.checksum
+  when:
+    - ansible_facts.services["rke2-server.service"] is defined
+    - tmp_sha1 != previous_rke2_config.stat.checksum
 
 - name: Restart rke2-agent if package installed and config changed
   service:
     state: restarted
     name: rke2-agent
-  when: "rke2-agent' in services" and tmp_sha1 != rke2_config.stat.checksum
+  when:
+    - ansible_facts.services["rke2-agent.service"] is defined
+    - tmp_sha1 != previous_rke2_config.stat.checksum

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -1,10 +1,21 @@
 ---
 
+- name: Does the /etc/rancher/rke2 dir exist?
+  stat:
+    path: /etc/rancher/rke2
+  register: rke2_directory
+
 - name: Create the /etc/rancher/rke2 config dir
   file:
     path: /etc/rancher/rke2
     state: directory
     recurse: yes
+  when: not rke2_directory.stat.exists
+
+- name: Does the /etc/rancher/rke2/config.yaml file exist?
+  stat:
+    path: /etc/rancher/rke2/config.yaml
+  register: rke2_config
 
 - name: create the /etc/rancher/rke2/config.yaml file
   file:
@@ -13,6 +24,7 @@
     mode: "0640"
     owner: root
     group: root
+  when: not rke2_config.stat.exists
 
 # --node-label value                     (agent/node) Registering and starting kubelet with set of labels
 # --node-taint value                     (agent/node) Registering kubelet with set of taints
@@ -46,7 +58,7 @@
   when: (node_ip is defined) and (node_ip|length > 0)
   register: updated_rke2_config
 
-- name: Update rke2_config to take value of updated_rke2_config
+- name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
@@ -60,7 +72,7 @@
   when: (node_name is defined) and (node_name|length > 0)
   register: updated_rke2_config
 
-- name: Update rke2_config to take value of updated_rke2_config
+- name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
@@ -74,7 +86,7 @@
   when: (bind_address is defined) and (bind_address|length > 0)
   register: updated_rke2_config
 
-- name: Update rke2_config to take value of updated_rke2_config
+- name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
@@ -89,7 +101,7 @@
   when: (advertise_address is defined) and (advertise_address|length > 0)
   register: updated_rke2_config
 
-- name: Update rke2_config to take value of updated_rke2_config
+- name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
@@ -103,10 +115,27 @@
   when: (node_external_ip is defined) and (node_external_ip|length > 0)
   register: updated_rke2_config
 
-- name: Update rke2_config to take value of updated_rke2_config
+- name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
   set_fact:
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
+
+- name: Create tmp config.yaml
+  copy:
+    content: "{{ rke2_config | to_nice_yaml(indent=0) }}"
+    dest: /tmp/ansible-config.txt
+    mode: "0600"
+    owner: root
+    group: root
+
+- name: Stat tmp config
+  stat:
+    path: /tmp/ansible-config.txt
+  register: tmp_config
+
+- name: Get cksum of tmp config
+  set_fact:
+    tmp_sha1: "{{ tmp_config.stat.checksum }}"
 
 - name: Drop in final /etc/rancher/rke2/config.yaml
   copy:
@@ -115,3 +144,16 @@
     mode: "0640"
     owner: root
     group: root
+  when: tmp_sha1 != rke2_config.stat.checksum
+
+- name: Restart rke2-server if package installed and config changed
+  service:
+    state: restarted
+    name: rke2-server
+  when: 'rke2-server' in services and tmp_sha1 != rke2_config.stat.checksum
+
+- name: Restart rke2-agent if package installed and config changed
+  service:
+    state: restarted
+    name: rke2-agent
+  when: "'rke2-agent' in services" and tmp_sha1 != rke2_config.stat.checksum

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -17,6 +17,17 @@
     path: /etc/rancher/rke2/config.yaml
   register: previous_rke2_config
 
+- name: Read previous_rke2_config
+  slurp:
+    src: /etc/rancher/rke2/config.yaml
+  register: full_orig_rke2_config
+  when: previous_rke2_config.stat.exists
+
+- name: Decode contents of slurp
+  set_fact:
+    orig_rke2_config: "{{ full_orig_rke2_config['content'] | b64decode }}"
+  when: previous_rke2_config.stat.exists
+
 - name: create the /etc/rancher/rke2/config.yaml file
   file:
     path: /etc/rancher/rke2/config.yaml
@@ -148,6 +159,12 @@
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: updated_rke2_config.changed
 
+- name: Remove tmp config file
+  ansible.builtin.file:
+    path: /tmp/ansible-config.txt
+    state: absent
+  changed_when: false
+
 - name: Create tmp config.yaml
   copy:
     content: "{{ rke2_config | to_nice_yaml(indent=0) }}"
@@ -155,6 +172,36 @@
     mode: "0600"
     owner: root
     group: root
+  when: previous_rke2_config.stat.exists
+  changed_when: false
+
+- name: Get original token
+  set_fact:
+    original_token: "{{ orig_rke2_config | regex_search('token: (.+)') }}"
+  when: previous_rke2_config.stat.exists
+  changed_when: false
+
+- name: Add token to config.yaml
+  lineinfile:
+    dest: /tmp/ansible-config.txt
+    line: "{{ original_token }}"
+    state: present
+    insertbefore: BOF
+  when: previous_rke2_config.stat.exists
+  changed_when: false
+
+- name: Get original server
+  set_fact:
+    original_server: "{{ orig_rke2_config | regex_search('server: https://(.*):9345') }}"
+  when: previous_rke2_config.stat.exists
+  changed_when: false
+
+- name: Add server url to config file
+  lineinfile:
+    dest: /tmp/ansible-config.txt
+    line: "{{ original_server }}"
+    state: present
+    insertbefore: BOF
   when: previous_rke2_config.stat.exists
   changed_when: false
 
@@ -181,12 +228,19 @@
     backup: yes
   when: not previous_rke2_config.stat.exists or (tmp_sha1 != previous_rke2_config.stat.checksum)
 
+- name: Remove tmp config file
+  ansible.builtin.file:
+    path: /tmp/ansible-config.txt
+    state: absent
+  changed_when: false
+
 - name: Restart rke2-server if package installed and config changed
   service:
     state: restarted
     name: rke2-server
   when:
     - ansible_facts.services["rke2-server.service"] is defined
+    - "ansible_facts.services['rke2-server.service'].state == 'running'"
     - tmp_sha1 != previous_rke2_config.stat.checksum
 
 - name: Restart rke2-agent if package installed and config changed
@@ -195,4 +249,5 @@
     name: rke2-agent
   when:
     - ansible_facts.services["rke2-agent.service"] is defined
+    - "ansible_facts.services['rke2-agent.service'].state == 'running'"
     - tmp_sha1 != previous_rke2_config.stat.checksum

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -25,9 +25,9 @@
   include: tarball_install.yml
   when:
     - |-
-      (ansible_facts['os_family'] != 'RedHat' and
+      ((ansible_facts['os_family'] != 'RedHat' and
       ansible_facts['os_family'] != 'Rocky') or
-      rke2_binary_tarball_check.stat.exists == true
+      rke2_binary_tarball_check.stat.exists == true)
       and not installed
 
 - name: RHEL/CentOS Installation
@@ -39,10 +39,10 @@
       setup: filter=ansible_lsb*
       when: "'redhat-lsb-core' not in ansible_facts.packages"
     - include: rpm_install.yml
+      when: not installed
   when:
     - ansible_os_family == 'RedHat' or ansible_os_family == 'Rocky'
     - rke2_binary_tarball_check.stat.exists == false
-    - not installed
 
 # Disable Firewalld
 # We recommend disabling firewalld. For Kubernetes 1.19+, firewalld must be turned off.

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -7,7 +7,11 @@
   package_facts:
     manager: auto
 
+- name: Has rke2 been installed already
+  include_tasks: previous_install.yml
+
 - include: images_tarball_install.yml
+  when: not installed
 
 - name: "Check for binary tarball in {{ playbook_dir }}/tarball_install/rke2.linux-amd64.tar.gz"
   stat:
@@ -15,6 +19,7 @@
   register: rke2_binary_tarball_check
   delegate_to: 127.0.0.1
   become: no
+  when: not installed
 
 - name: SLES/Ubuntu/Tarball Installation
   include: tarball_install.yml
@@ -23,6 +28,7 @@
       (ansible_facts['os_family'] != 'RedHat' and
       ansible_facts['os_family'] != 'Rocky') or
       rke2_binary_tarball_check.stat.exists == true
+      and not installed
 
 - name: RHEL/CentOS Installation
   block:
@@ -36,6 +42,7 @@
   when:
     - ansible_os_family == 'RedHat' or ansible_os_family == 'Rocky'
     - rke2_binary_tarball_check.stat.exists == false
+    - not installed
 
 # Disable Firewalld
 # We recommend disabling firewalld. For Kubernetes 1.19+, firewalld must be turned off.

--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Check if rke2-server is previously installed
+  ansible.builtin.debug:
+    msg: "rke2-server is already installed. Skipping installation steps."
+  when: "'rke2-server' in services"
+
+- name: Set fact if rke2-server was previously installed
+  set_fact:
+    installed: true
+  when: "'rke2-server' in services"
+
+- name: Check if rke2-agent is previously installed
+  ansible.builtin.debug:
+    msg: "rke2-agent is already installed. Skipping installation steps."
+  when: "'rke2-agent' in services"
+
+- name: Set fact if rke2-agent was previously installed
+  set_fact:
+    installed: true
+  when: "'rke2-agent' in services"

--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -3,19 +3,19 @@
 - name: Check if rke2-server is previously installed
   ansible.builtin.debug:
     msg: "rke2-server is already installed. Skipping installation steps."
-  when: "'rke2-server' in services"
+  when: ansible_facts.services["rke2-server.service"] is defined
 
 - name: Set fact if rke2-server was previously installed
   set_fact:
     installed: true
-  when: "'rke2-server' in services"
+  when: ansible_facts.services["rke2-server.service"] is defined
 
 - name: Check if rke2-agent is previously installed
   ansible.builtin.debug:
     msg: "rke2-agent is already installed. Skipping installation steps."
-  when: "'rke2-agent' in services"
+  when: ansible_facts.services["rke2-agent.service"] is defined
 
 - name: Set fact if rke2-agent was previously installed
   set_fact:
     installed: true
-  when: "'rke2-agent' in services"
+  when: ansible_facts.services["rke2-agent.service"] is defined

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -16,6 +16,7 @@
     state: directory
     suffix: rke2-install.XXXXXXXXXX
   register: temp_dir
+  when: "'rke2-server' not in services or 'rke2-agent' not in services"
 
 - name: Send provided tarball if available
   copy:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -41,7 +41,6 @@
         url: https://update.rke2.io/v1-release/channels/{{ rke2_channel }}
         follow_redirects: all
       register: rke2_version_url
-      run_once: yes
 
     - name: Set full version name
       shell: set -o pipefail && echo {{ rke2_version_url.url }} | sed -e 's|.*/||'
@@ -49,7 +48,6 @@
       changed_when: false
       args:
         executable: /bin/bash
-      run_once: yes
 
     - name: Set dot version
       shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /usr/bin/cut -d'+' -f1
@@ -57,7 +55,6 @@
       changed_when: false
       args:
         executable: /bin/bash
-      run_once: yes
 
     - name: Set Maj.Min version
       shell: >-
@@ -67,7 +64,6 @@
       changed_when: false
       args:
         executable: /bin/bash
-      run_once: yes
 
     - name: Describe versions
       debug:
@@ -75,6 +71,7 @@
           - "Full version: {{ rke2_full_version.stdout }}"
           - "dot version: {{ rke2_version_dot.stdout }}"
           - "Maj.Min version: {{ rke2_version.stdout }}"
+      run_once: yes
 
     - name: TARBALL | Download the tarball
       get_url:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -16,7 +16,10 @@
     state: directory
     suffix: rke2-install.XXXXXXXXXX
   register: temp_dir
-  when: ansible_facts.services["rke2-server.service"] is not defined or ansible_facts.services["rke2-agent.service"] is not defined
+  when:
+    - |-
+      ansible_facts.services["rke2-server.service"] is not defined or
+      ansible_facts.services["rke2-agent.service"] is not defined
 
 - name: Send provided tarball if available
   copy:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -16,7 +16,7 @@
     state: directory
     suffix: rke2-install.XXXXXXXXXX
   register: temp_dir
-  when: "'rke2-server' not in services or 'rke2-agent' not in services"
+  when: ansible_facts.services["rke2-server.service"] is not defined or ansible_facts.services["rke2-agent.service"] is not defined
 
 - name: Send provided tarball if available
   copy:

--- a/roles/rke2_common/vars/main.yml
+++ b/roles/rke2_common/vars/main.yml
@@ -5,3 +5,5 @@ channels:
   - latest
   - v1.19
   - v1.18
+
+installed: false

--- a/roles/rke2_server/tasks/other_servers.yml
+++ b/roles/rke2_server/tasks/other_servers.yml
@@ -1,14 +1,34 @@
 ---
 
-- name: Add server url to config file
-  lineinfile:
-    dest: /etc/rancher/rke2/config.yaml
-    line: "server: https://{{ kubernetes_api_server_host }}:9345"
+- name: Does config file already have server token?  # noqa command-instead-of-shell
+  ansible.builtin.command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
+  register: server_token_check
+  failed_when: server_token_check.rc >= 2
+  changed_when: false
 
 - name: Add token to config.yaml
   lineinfile:
     dest: /etc/rancher/rke2/config.yaml
     line: "token: {{ hostvars[groups['rke2_servers'][0]].rke2_config_token }}"
+    state: present
+    insertbefore: BOF
+  when:
+    - '"token:" not in server_token_check.stdout'
+
+- name: Does config file already have server url?  # noqa command-instead-of-shell
+  ansible.builtin.command: 'grep -i "^server:" /etc/rancher/rke2/config.yaml'
+  register: server_url_check
+  failed_when: server_url_check.rc >= 2
+  changed_when: false
+
+- name: Add server url to config file
+  lineinfile:
+    dest: /etc/rancher/rke2/config.yaml
+    line: "server: https://{{ kubernetes_api_server_host }}:9345"
+    state: present
+    insertbefore: BOF
+  when:
+    - '"server:" not in server_url_check.stdout'
 
 - name: Start and wait for healthy node
   throttle: 1

--- a/testing/basic_common_tests.py
+++ b/testing/basic_common_tests.py
@@ -1,0 +1,9 @@
+from kubernetes import client, config
+
+
+config.load_kube_config()
+v1 = client.CoreV1Api()
+print("Listing pods with their IPs:")
+ret = v1.list_pod_for_all_namespaces(watch=False)
+for i in ret.items:
+    print("%s\t%s" % (i.status.pod_ip, i.metadata.name))

--- a/testing/main.tf
+++ b/testing/main.tf
@@ -53,7 +53,6 @@ resource "aws_instance" "control_node" {
 
   tags = {
     Name        = "rke2_ansible-testing-server-${var.os}-${var.GITHUB_RUN_ID}-${count.index}"
-    StopAtNight = "True"
     Owner       = var.tf_user
     NodeType    = "Server"
     github_run  = "${var.GITHUB_RUN_ID}"
@@ -91,9 +90,45 @@ resource "aws_instance" "worker_node" {
 
   tags = {
     Name        = "rke2_ansible-testing-agent-${var.os}-${var.GITHUB_RUN_ID}-${count.index}"
-    StopAtNight = "True"
     Owner       = var.tf_user
     NodeType    = "Agent"
+    github_run  = "${var.GITHUB_RUN_ID}"
+  }
+
+  provisioner "remote-exec" {
+    connection {
+      host        = coalesce(self.public_ip, self.private_ip)
+      type        = "ssh"
+      user        = "ubuntu"
+      private_key = file(pathexpand(".key"))
+    }
+    inline = [
+      "uptime",
+    ]
+  }
+}
+
+# EC2 Instance for RKE2 Cluster - Workers
+resource "aws_instance" "extra_worker_node" {
+  count = var.extra_worker_nodes
+
+  ami                         = lookup(var.amis[var.aws_region], var.os)
+  instance_type               = var.instance_type
+  subnet_id                   = var.aws_subnet
+  key_name                    = "rke2-ansible-ci"
+  associate_public_ip_address = true
+
+  vpc_security_group_ids = [aws_security_group.allow-all.id]
+
+  root_block_device {
+    volume_type = "standard"
+    volume_size = 60
+  }
+
+  tags = {
+    Name        = "rke2_ansible-testing-agent-idempotency-${var.os}-${var.GITHUB_RUN_ID}-${count.index}"
+    Owner       = var.tf_user
+    NodeType    = "ExtraNode"
     github_run  = "${var.GITHUB_RUN_ID}"
   }
 

--- a/testing/variables.tf
+++ b/testing/variables.tf
@@ -61,7 +61,13 @@ variable "control_nodes" {
 variable "worker_nodes" {
   type        = number
   description = "Number of RKE2 worker nodes"
-  default     = 3
+  default     = 2
+}
+
+variable "extra_worker_nodes" {
+  type        = number
+  description = "Number of RKE2 worker nodes to add for idempotency tests"
+  default     = 2
 }
 
 variable "ansible_user" {


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [X ] feature

## What this PR does / why we need it:
You should be able to run this playbook repeatedly without fear of changes to your cluster if no changes were made in variables/configs.  This also allows for adding hosts.

## Which issue(s) this PR fixes:

Fixes #46 

## Testing
The CI tests have changed to verify this change.  The tests run the playbook multiple times to make sure that no changes are made. The tests also adds hosts after the initial run and after the idempotency run.  The ansible and python tests are run a second time after the new hosts are added.