### PR TITLE
hot_fix_01_idempotency_fix

### DIFF
--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -19,7 +19,6 @@
   register: rke2_binary_tarball_check
   delegate_to: 127.0.0.1
   become: no
-  when: not installed
 
 - name: SLES/Ubuntu/Tarball Installation
   include: tarball_install.yml


### PR DESCRIPTION
## What type of PR is this?

- [X ] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:
Removing the `when: not installed` because the next `when:` needs the register created by the previous step

## Special notes:
Issue found by @jmkelm08
https://github.com/rancherfederal/rke2-ansible/pull/85#issuecomment-929518152