### PR TITLE
Enable RPM installs in air-gapped envs via custom yum repos (#89)

### DIFF
--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -4,4 +4,20 @@ rke2_channel: stable
 audit_policy_config_file_path: ""
 registry_config_file_path: ""
 add_iptables_rules: false
+rke2_common_repo:
+  name: rke2-common
+  description: "Rancher RKE2 Common Latest"
+  baseurl: "https://rpm.rancher.io/rke2/latest/common/centos/$releasever/noarch"
+  gpgcheck: true
+  gpgkey: "https://rpm.rancher.io/public.key"
+  enabled: yes
+
+rke2_versioned_yum_repo:
+  name: "rke2-v{{ rke2_vesion_majmin }}"  # noqa var-spacing
+  description: "Rancher RKE2 Version"
+  baseurl: "https://rpm.rancher.io/rke2/latest/{{ rke2_version_majmin }}/centos/$releasever/$basearch"
+  gpgcheck: true
+  gpgkey: "https://rpm.rancher.io/public.key"
+  enabled: yes
+
 rke2_config: {}

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -1,100 +1,126 @@
 ---
-- name: Stop if the provided channel is not valid
-  fail:
-    msg: "Provided channel is not valid"
-  when: rke2_channel not in channels
+- name: Calculate rke2_full_version
+  when: (install_rke2_version is not defined) or (install_rke2_version|length == 0)
+  block:
+  - name: Stop if the provided is not valid
+    fail:
+      msg: "Provided channel is not valid"
+    when: rke2_channel not in channels
 
-- name: Get full version name url
-  uri:
-    url: https://update.rke2.io/v1-release/channels/{{ rke2_channel }}
-    follow_redirects: all
-  register: rke2_version_url
+  - name: Get full version name url
+    uri:
+      url: https://update.rke2.io/v1-release/channels/{{ rke2_channel }}
+      follow_redirects: all
+    register: rke2_version_url
 
-- name: Set full version name
-  shell: set -o pipefail && echo {{ rke2_version_url.url }} | sed -e 's|.*/||'
-  register: rke2_full_version
-  changed_when: false
-  args:
-    executable: /usr/bin/bash
+  - name: Set full version name
+    shell: set -o pipefail && echo {{ rke2_version_url.url }} | sed -e 's|.*/||'
+    register: rke2_full_version
+    changed_when: false
+    args:
+      executable: /usr/bin/bash
+
+- name: Set rke2_full_version fact
+  set_fact:
+    rke2_full_version: "{{ rke2_full_version.stdout if ((install_rke2_version is not defined) or (install_rke2_version|length == 0)) else install_rke2_version }}"
 
 - name: Set dot version
-  shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /usr/bin/cut -d'+' -f1
+  shell: set -o pipefail && echo {{ rke2_full_version }} | /usr/bin/cut -d'+' -f1
   register: rke2_version_dot
   changed_when: false
   args:
     executable: /usr/bin/bash
 
+- name: Set rke2_version_dot fact
+  set_fact:
+    rke2_version_dot: "{{ rke2_version_dot.stdout }}"
+
 - name: Set Maj.Min version
-  shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /bin/awk -F'.' '{ print $1"."$2 }' | sed "s|^v||g"
-  register: rke2_version
+  shell: set -o pipefail && echo {{ rke2_full_version }} | /bin/awk -F'.' '{ print $1"."$2 }' | sed "s|^v||g"
+  register: rke2_version_majmin
   changed_when: false
   args:
     executable: /usr/bin/bash
 
+- name: Set rke2_version_majmin fact
+  set_fact:
+    rke2_version_majmin: "{{ rke2_version_majmin.stdout }}"
+
+- name: Set RPM version
+  shell: set -o pipefail && echo {{ rke2_full_version }} | sed -E -e "s/[\+-]/~/g" | sed -E -e "s/v(.*)/\1/"
+  register: rke2_version_rpm
+  changed_when: false
+  args:
+    executable: /usr/bin/bash
+
+- name: Set rke2_version_rpm fact
+  set_fact:
+    rke2_version_rpm: "{{ rke2_version_rpm.stdout }}"
+
 - name: Describe versions
   debug:
-    msg: >
-      Full version: {{ rke2_full_version.stdout }}, dot version: {{ rke2_version_dot.stdout }}
-      Maj.Min version: {{ rke2_version.stdout }}"
+    msg:
+    - "Full version: {{ rke2_full_version }}, dot version: {{ rke2_version_dot }}"
+    - "Maj.Min version: {{ rke2_version_majmin }}, rpm version: {{ rke2_version_rpm }}"
 
 # Does the Rancher RKE2 Common repo exist already
 - name: Check to see if rke2-common.repo exists
   stat:
     path: '/etc/yum.repos.d/rke2-common.repo'
-  register: stat_rke2_common
+  register: stat_rke2_common_repo
 
 # Add RKE2 Common repo if it doesn't exist
-- name: add the rke2-common repo RHEL/CentOS 7
+- name: Add the rke2-common repo RHEL/CentOS 7
   yum_repository:
-    name: rke2-common
-    description: Rancher RKE2 Common Latest
-    baseurl: "https://rpm.rancher.io/rke2/latest/common/centos/7/noarch"
-    gpgcheck: true
-    gpgkey: "https://rpm.rancher.io/public.key"
-    enabled: yes
-  when: not stat_rke2_common.stat.exists and ansible_lsb.major_release == '7'
+    name: "{{ rke2_common_yum_repo.name }}"
+    description: "{{ rke2_common_yum_repo.description }}"
+    baseurl: "{{ rke2_common_yum_repo.baseurl }}"
+    gpgcheck: "{{ rke2_common_yum_repo.gpgcheck }}"
+    gpgkey: "{{ rke2_common_yum_repo.gpgkey }}"
+    enabled: "{{ rke2_common_yum_repo.enabled }}"
+  when: not stat_rke2_common_repo.stat.exists and ansible_lsb.major_release == '7'
 
-- name: add the rke2-common repo RHEL/CentOS 8
+- name: Add the rke2-common repo RHEL/CentOS 8
   yum_repository:
-    name: rke2-common
-    description: Rancher RKE2 Common Latest
-    baseurl: "https://rpm.rancher.io/rke2/latest/common/centos/8/noarch"
-    gpgcheck: true
-    gpgkey: "https://rpm.rancher.io/public.key"
-    enabled: yes
-  when: not stat_rke2_common.stat.exists and ansible_lsb.major_release == '8'
+    name: "{{ rke2_common_yum_repo.name }}"
+    description: "{{ rke2_common_yum_repo.description }}"
+    baseurl: "{{ rke2_common_yum_repo.baseurl }}"
+    gpgcheck: "{{ rke2_common_yum_repo.gpgcheck }}"
+    gpgkey: "{{ rke2_common_yum_repo.gpgkey }}"
+    enabled: "{{ rke2_common_yum_repo.enabled }}"
+  when: not stat_rke2_common_repo.stat.exists and ansible_lsb.major_release == '8'
 
 # Does the Rancher RKE2 versioned repo exist already
 - name: Check to see if rke2 versioned repo exists
   stat:
-    path: '/etc/yum.repos.d/rke2-v{{ rke2_version.stdout }}.repo'  # noqa var-spacing
+    path: '/etc/yum.repos.d/rke2-v{{ rke2_version_majmin }}.repo'  # noqa var-spacing
   register: stat_rke2_versioned_repo
 
 # Add RKE2 versioned repo if it doesn't exist
 - name: Add the rke2 versioned repo CentOS/RHEL 7
   yum_repository:
-    name: "rke2-v{{ rke2_version.stdout }}"  # noqa var-spacing
-    description: Rancher RKE2 Version
-    baseurl: "https://rpm.rancher.io/rke2/latest/{{ rke2_version.stdout }}/centos/7/x86_64"
-    gpgcheck: true
-    gpgkey: "https://rpm.rancher.io/public.key"
-    enabled: yes
-  when: (not stat_rke2_versioned_repo.stat.exists) and (ansible_lsb.major_release == '7')
+    name: "{{ rke2_versioned_yum_repo.name }}"
+    description: "{{ rke2_versioned_yum_repo.description }}"
+    baseurl: "{{ rke2_versioned_yum_repo.baseurl }}"
+    gpgcheck: "{{ rke2_versioned_yum_repo.gpgcheck }}"
+    gpgkey: "{{ rke2_versioned_yum_repo.gpgkey }}"
+    enabled: "{{ rke2_versioned_yum_repo.enabled }}"
+  when: not stat_rke2_versioned_repo.stat.exists and ansible_lsb.major_release == '7'
 
-- name: add the rke2 versioned repo CentOS/RHEL 8
+- name: Add the rke2 versioned repo CentOS/RHEL 8
   yum_repository:
-    name: "rke2-v{{ rke2_version.stdout }}"  # noqa var-spacing
-    description: Rancher RKE2 Version
-    baseurl: "https://rpm.rancher.io/rke2/latest/{{ rke2_version.stdout }}/centos/8/x86_64"
-    gpgcheck: true
-    gpgkey: "https://rpm.rancher.io/public.key"
-    enabled: yes
-  when: (not stat_rke2_versioned_repo.stat.exists) and (ansible_lsb.major_release == '8')
+    name: "{{ rke2_versioned_yum_repo.name }}"
+    description: "{{ rke2_versioned_yum_repo.description }}"
+    baseurl: "{{ rke2_versioned_yum_repo.baseurl }}"
+    gpgcheck: "{{ rke2_versioned_yum_repo.gpgcheck }}"
+    gpgkey: "{{ rke2_versioned_yum_repo.gpgkey }}"
+    enabled: "{{ rke2_versioned_yum_repo.enabled }}"
+  when: not stat_rke2_versioned_repo.stat.exists and ansible_lsb.major_release == '8'
 
 - name: YUM-Based | Install rke2-server
   yum:
-    name: rke2-server
-    state: latest  # noqa package-latest
+    name: "rke2-server-{{ rke2_version_rpm }}"
+    state: present  # noqa package-latest
   when:
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists
@@ -102,8 +128,8 @@
 
 - name: YUM-Based | Install rke2-agent
   yum:
-    name: rke2-agent
-    state: latest  # noqa package-latest
+    name: "rke2-agent-{{ rke2_version_rpm }}"
+    state: present  # noqa package-latest
   when:
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists


### PR DESCRIPTION
Enable RPM installs in air-gapped environments via custom yum repos and explicit specification of the desired install_rke2_version (#89)

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

_(REQUIRED)_

According to feedback from issue https://github.com/rancherfederal/rke2-ansible/issues/86, both RKE2 and rke2-ansible do not support Tarball installs with SELinux enforcing. Furthermore, rke2-ansible today only supports Tarball installs for Air-Gapped environments. So, this PR introduces support for RPM installs with SELinux enforcing in Air-Gapped environments. This is achieved by delivering the following features:
- the rke2 common and rke2 versioned yum repo definitions can be overridden to reference local repos presumably created in the airgapped environment using the yum reposync and createrepo utilities
- allow explicit specification of the `install_rke2_version` to eliminate a hard dependency on the RKE2 Update service available at internet url: https://update.rke2.io

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #89

## Special notes for your reviewer:

## Testing

1. Tested using defaults while connected to the internet

2. Tested in air-gapped environment with two CentOS 7 hosts, Ansible local server ip-10-11-12-13 and Apache HTTPD server ip-9-11-12-13. The Ansible local server runs ansible and is also the rke2_server target. The Apache HTTPD server hosts rke2-common and rke2-v1.21 yum repos. These repos were extracted from a tar archive transferred from an internet-connected machine. The tar archive was created on the internet-connected machine by archiving a directory created by the yum reposync and createrepo tools.

The air-gapped inventory files were defined as follows:
```
mkdir -p rke2-ansible/inventory/my-cluster/group_vars
cd rke2-ansible

cat <<EOF > inventory/my-cluster/hosts.ini
[rke2_servers]
ip-10-11-12-13 ipv4addr=10.11.12.13

[rke2_agents]

[rke2_cluster:children]
rke2_servers
rke2_agents
EOF

cat <<EOF > inventory/my-cluster/group_vars/rke2_servers.yml
---
rke2_config:
  selinux: true
EOF

cat <<EOF > inventory/my-cluster/group_vars/rke2_agents.yml
---
rke2_config:
  selinux: true
EOF

cat <<EOF > inventory/my-cluster/group_vars/all.yml
---
install_rke2_version: "v1.21.5+rke2r1"

rke2_common_yum_repo:
  name: "rke2-common"
  description: "Rancher RKE2 Common Latest"
  baseurl: "http://ip-9-11-12-13:8080/mrepo/rancher/rke2/latest/common/centos/$releasever/noarch"
  gpgcheck: false
  gpgkey: "https://rpm.rancher.io/public.key"
  enabled: yes

rke2_versioned_yum_repo:
  name: "rke2-v{{ rke2_version_majmin }}"  # noqa var-spacing"
  description: "Rancher RKE2 Version"
  baseurl: "http://ip-9-11-12-13:8080/mrepo/rancher/rke2/latest/{{ rke2_version_majmin }}/centos/$releasever/$basearch"
  gpgcheck: false
  gpgkey: "https://rpm.rancher.io/public.key"
  enabled: yes
EOF
```
Ansible was invoked using the following command:
```
ansible-playbook site.yml -i ./inventory/my-cluster/hosts.ini -c local
```

## Release Notes

_(REQUIRED)_

Enable RPM installs in air-gapped environments via custom yum repos and explicit specification of the desired install_rke2_version (#89)