### PR TITLE
Eliminate use of ansible.builtin.command to work-around ansible regression (#90)

### DIFF
--- a/roles/rke2_agent/tasks/main.yml
+++ b/roles/rke2_agent/tasks/main.yml
@@ -6,7 +6,7 @@
     tasks_from: main
 
 - name: Does config file already have server token?  # noqa command-instead-of-shell
-  ansible.builtin.command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
+  command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
   register: server_token_check
   failed_when: server_token_check.rc >= 2
   changed_when: false
@@ -21,7 +21,7 @@
     - '"token:" not in server_token_check.stdout'
 
 - name: Does config file already have server url?  # noqa command-instead-of-shell
-  ansible.builtin.command: 'grep -i "^server:" /etc/rancher/rke2/config.yaml'
+  command: 'grep -i "^server:" /etc/rancher/rke2/config.yaml'
   register: server_url_check
   failed_when: server_url_check.rc >= 2
   changed_when: false

--- a/roles/rke2_server/tasks/other_servers.yml
+++ b/roles/rke2_server/tasks/other_servers.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Does config file already have server token?  # noqa command-instead-of-shell
-  ansible.builtin.command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
+  command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
   register: server_token_check
   failed_when: server_token_check.rc >= 2
   changed_when: false
@@ -16,7 +16,7 @@
     - '"token:" not in server_token_check.stdout'
 
 - name: Does config file already have server url?  # noqa command-instead-of-shell
-  ansible.builtin.command: 'grep -i "^server:" /etc/rancher/rke2/config.yaml'
+  command: 'grep -i "^server:" /etc/rancher/rke2/config.yaml'
   register: server_url_check
   failed_when: server_url_check.rc >= 2
   changed_when: false


### PR DESCRIPTION
Eliminate use of ansible.builtin.command to work-around ansible issue https://github.com/ansible/ansible/pull/71824. This is consistent with the fix for rke2-ansible issue https://github.com/rancherfederal/rke2-ansible/issues/69.

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

Eliminate use of ansible.builtin.command to work-around ansible issue https://github.com/ansible/ansible/pull/71824. This  regression is believed to present in many Ansible installations.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #90 

## Special notes for your reviewer:

## Testing

## Release Notes

_(REQUIRED)_

```Eliminate use of ansible.builtin.command to work-around ansible issue https://github.com/ansible/ansible/pull/71824```

