### PR TITLE
Removing action configure-aws-credentials and added AWS_ vars

### DIFF
--- a/.github/workflows/vanilla_ubuntu.yml
+++ b/.github/workflows/vanilla_ubuntu.yml
@@ -6,6 +6,11 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: us-gov-west-1
+
 jobs:
 
   lint-test:
@@ -44,14 +49,6 @@ jobs:
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2
-
-      - name: Configure AWS credentials
-        id: creds
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
 
       - name: Terraform Init
         id: init


### PR DESCRIPTION
"Removing aws-actions/configure-aws-credentials and added AWS_ vars to env:"

## What type of PR is this?

- [X] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:
This fixes the testing fails. The aws-actions/configure-aws-credentials project changed the requirements to better work with Cloudformation.  Since this project uses Terraform setting the AWS_ env vars is all that is required.

## Testing

Current PRs may need to merge this in before their tests can work.

## Release Notes

```release-note
NONE
```

