### PR TITLE
Remove node and Uninstall RKE2

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -167,6 +167,22 @@ jobs:
           pytest --hosts=rke2_servers --ansible-inventory=inventory/centos7/hosts.ini --force-ansible --connection=ansible --sudo testing/basic_server_tests.py
           pytest --hosts=rke2_agents --ansible-inventory=inventory/centos7/hosts.ini --force-ansible --connection=ansible --sudo testing/basic_agent_tests.py
 
+      - name: Move some worker nodes into [rke2_uninstall]
+        run: |
+          rm hosts.ini
+          touch hosts.ini
+          echo "[rke2_servers]" > hosts.ini
+          aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=Server" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
+          echo "[rke2_agents]" >> hosts.ini
+          aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=ExtraNode" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
+          echo "[rke2_uninstall" >> hosts.ini
+          aws ec2 describe-instances --filters "Name=tag:Owner,Values=rke2-ansible-github-actions" "Name=tag:NodeType,Values=Agent" "Name=tag:github_run,Values=$GITHUB_RUN_ID" --query "Reservations[*].Instances[*].PublicIpAddress" --output text >> hosts.ini
+          cp hosts.ini inventory/centos7/hosts.ini
+
+      - name: Run playbook again with uninstall
+        run: |
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory/centos7/hosts.ini -u centos --verbose --private-key .key site.yml
+
       - name: Delete Stack
         if: ${{ always() }}
         run: |

--- a/README.md
+++ b/README.md
@@ -116,19 +116,22 @@ Uninstall RKE2
     Note: Uninstalling RKE2 deletes the cluster data and all of the scripts.
 The offical documentation for fully uninstalling the RKE2 cluster can be found in the [RKE2 Documentation](https://docs.rke2.io/install/uninstall/).
 
-If you used this module to created the cluster and RKE2 was installed via yum, then you can attempt to run this command to remove all cluster data and all RKE2 scripts.
+Nodes can be removed from a cluster and RKE2 uninstalled by adding the node to the [rke2_uninstall] section of the hosts file.
 
-Replace `ec2-user` with your ansible user.
 ```bash
-ansible -i 18.217.113.10, all -u ec2-user -a "/usr/bin/rke2-uninstall.sh"
-```
+[rke2_servers]
+192.16.35.12
 
-If the tarball method was used then you can attempt to use the following command:
-```bash
-ansible -i 18.217.113.10, all -u ec2-user -a "/usr/local/bin/rke2-uninstall.sh"
-```
-On rare occasions you may have to run the uninstall commands a second time.
+[rke2_agents]
+192.16.35.10
 
+[rke2_uninstall]
+192.16.35.11
+
+[rke2_cluster:children]
+rke2_servers
+rke2_agents
+```
 
 Author Information
 ------------------

--- a/roles/rke2_uninstall/tasks/clean_node.yml
+++ b/roles/rke2_uninstall/tasks/clean_node.yml
@@ -47,7 +47,7 @@
         state: absent
       when: rke2_rpm_patch_version|int <= 12
 
-# yamllint disable rule:line-length
+    # yamllint disable rule:line-length
     - name: Download rke2-uninstall.sh script
       get_url:
         url: https://raw.githubusercontent.com/rancher/rke2/488bab0f48b848e408ce399c32e7f5f73ce96129/bundle/bin/rke2-uninstall.sh
@@ -61,7 +61,7 @@
         dest: /usr/local/bin/rke2-killall.sh
         mode: '775'
       when: rke2_rpm_patch_version|int <= 11
-# yamllint enable rule:line-length
+    # yamllint enable rule:line-length
 
     - name: Uninstall for versions prior to v1.18.11+rke2r1
       shell: set -o pipefail && /usr/local/bin/rke2-uninstall.sh

--- a/roles/rke2_uninstall/tasks/clean_node.yml
+++ b/roles/rke2_uninstall/tasks/clean_node.yml
@@ -1,3 +1,4 @@
+---
 - name: Was rke2 installed via tarball?
   stat:
     path: /usr/local/bin/rke2-uninstall.sh
@@ -46,6 +47,7 @@
         state: absent
       when: rke2_rpm_patch_version|int <= 12
 
+# yamllint disable rule:line-length
     - name: Download rke2-uninstall.sh script
       get_url:
         url: https://raw.githubusercontent.com/rancher/rke2/488bab0f48b848e408ce399c32e7f5f73ce96129/bundle/bin/rke2-uninstall.sh
@@ -59,6 +61,7 @@
         dest: /usr/local/bin/rke2-killall.sh
         mode: '775'
       when: rke2_rpm_patch_version|int <= 11
+# yamllint enable rule:line-length
 
     - name: Uninstall for versions prior to v1.18.11+rke2r1
       shell: set -o pipefail && /usr/local/bin/rke2-uninstall.sh

--- a/roles/rke2_uninstall/tasks/clean_node.yml
+++ b/roles/rke2_uninstall/tasks/clean_node.yml
@@ -1,0 +1,67 @@
+- name: Was rke2 installed via tarball?
+  stat:
+    path: /usr/local/bin/rke2-uninstall.sh
+  register: tarball_uninstall
+
+- name: Uninstall rke2 from tarball
+  block:
+    - name: Uninstall rke2 from tarball
+      shell: set -o pipefail && /usr/local/bin/rke2-uninstall.sh
+  when: tarball_uninstall.stat.exists
+
+- name: Uninstall rke2 from RPM
+  block:
+    - name: Use rke2 binary to get full version
+      shell: set -o pipefail && rke2 --version | egrep -o "v1.[0-9]{1,4}.[0-9]{1,4}"
+      register: rke2_rpm_version
+
+    - name: Get minor version
+      shell: set -o pipefail && echo {{ rke2_rpm_version }} | /usr/bin/cut -d'.' -f2
+      register: rke2_rpm_minor_version
+
+    - name: Get patch version
+      shell: set -o pipefail && echo {{ rke2_rpm_version }} | /usr/bin/cut -d'.' -f3
+      register: rke2_rpm_patch_version
+
+    # Order of uninstall by version taken from:
+    # https://docs.rke2.io/install/linux_uninstall/#rpm-method
+    - name: Uninstall for version RKE2 v1.18.13+rke2r1 and newer
+      shell: set -o pipefail && /usr/bin/rke2-uninstall.sh
+      when: rke2_rpm_patch_version|int >= 13
+
+    - name: Uninstall for version RKE2 v1.18.12
+      shell: set -o pipefail && /usr/bin/rke2-uninstall.sh
+      when: rke2_rpm_patch_version|int == 12
+
+    - name: yum uninstall "rke2-*"
+      yum:
+        name: 'rke2-*'
+        state: absent
+        autoremove: yes
+      when: rke2_rpm_patch_version|int <= 12
+
+    - name: Remove /run/k3s
+      file:
+        path: /run/k3s
+        state: absent
+      when: rke2_rpm_patch_version|int <= 12
+
+    - name: Download rke2-uninstall.sh script
+      get_url:
+        url: https://raw.githubusercontent.com/rancher/rke2/488bab0f48b848e408ce399c32e7f5f73ce96129/bundle/bin/rke2-uninstall.sh
+        dest: /usr/local/bin/rke2-uninstall.sh
+        mode: '775'
+      when: rke2_rpm_patch_version|int <= 11
+
+    - name: Download rke2-uninstall.sh script
+      get_url:
+        url: https://raw.githubusercontent.com/rancher/rke2/488bab0f48b848e408ce399c32e7f5f73ce96129/bundle/bin/rke2-killall.sh
+        dest: /usr/local/bin/rke2-killall.sh
+        mode: '775'
+      when: rke2_rpm_patch_version|int <= 11
+
+    - name: Uninstall for versions prior to v1.18.11+rke2r1
+      shell: set -o pipefail && /usr/local/bin/rke2-uninstall.sh
+      when: rke2_rpm_patch_version|int <= 11
+
+  when: not tarball_uninstall.stat.exists

--- a/roles/rke2_uninstall/tasks/kubectl.yml
+++ b/roles/rke2_uninstall/tasks/kubectl.yml
@@ -1,3 +1,4 @@
+---
 - name: Ensure kubelet process is present on host
   command: >-
     ps -C kubelet -F -ww --no-headers
@@ -7,12 +8,14 @@
   delay: 10
   changed_when: false
 
+# yamllint disable rule:line-length
 - name: Extract the hostname-override parameter from the kubelet process
   set_fact:
     kubelet_hostname_override_parameter: "{{ kubelet_check.stdout |\
       regex_search('\\s--hostname-override=((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
       '\\1') }}"
   changed_when: false
+# yamllint enable rule:line-length
 
 - name: Label node as toBeDeleted
   command: >-

--- a/roles/rke2_uninstall/tasks/kubectl.yml
+++ b/roles/rke2_uninstall/tasks/kubectl.yml
@@ -1,0 +1,56 @@
+- name: Ensure kubelet process is present on host
+  command: >-
+    ps -C kubelet -F -ww --no-headers
+  register: kubelet_check
+  until: kubelet_check.rc == 0
+  retries: 20
+  delay: 10
+  changed_when: false
+
+- name: Extract the hostname-override parameter from the kubelet process
+  set_fact:
+    kubelet_hostname_override_parameter: "{{ kubelet_check.stdout |\
+      regex_search('\\s--hostname-override=((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
+      '\\1') }}"
+  changed_when: false
+
+- name: Label node as toBeDeleted
+  command: >-
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    --server https://127.0.0.1:6443 label nodes {{ kubelet_hostname_override_parameter[0] }} toBeDeleted=true
+  delegate_to: "{{ groups['rke2_servers'][0] }}"
+  register: added_label
+  changed_when: false
+
+- name: Use kubectl to cordon node
+  command: >-
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    --server https://127.0.0.1:6443 cordon {{ kubelet_hostname_override_parameter[0] }}
+  delegate_to: "{{ groups['rke2_servers'][0] }}"
+  changed_when: false
+
+- name: Verify node is cordoned
+  command: >-
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    --server https://127.0.0.1:6443 get no {{ kubelet_hostname_override_parameter[0] }}
+    -o jsonpath='{.spec.taints[?(@.key=="node.kubernetes.io/unschedulable")].effect}'
+  until: status_result.stdout.find("NoSchedule") != -1
+  retries: 20
+  delay: 10
+  register: status_result
+  delegate_to: "{{ groups['rke2_servers'][0] }}"
+  changed_when: false
+
+- name: Use kubectl to drain node
+  command: >-
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    --server https://127.0.0.1:6443 drain {{ kubelet_hostname_override_parameter[0] }} --ignore-daemonsets
+  delegate_to: "{{ groups['rke2_servers'][0] }}"
+  changed_when: false
+
+- name: Use kubectl to delete node
+  command: >-
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    --server https://127.0.0.1:6443 delete node {{ kubelet_hostname_override_parameter[0] }}
+  delegate_to: "{{ groups['rke2_servers'][0] }}"
+  changed_when: false

--- a/roles/rke2_uninstall/tasks/main.yml
+++ b/roles/rke2_uninstall/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# https://docs.rke2.io/install/linux_uninstall/
+
+- name: Use kubectl to cordon, drain, and delete
+  include_tasks: kubectl.yml
+  when: inventory_hostname in groups['rke2_uninstall']
+
+- name: Use uninstall scripts
+  include_tasks: clean_node.yml
+  when: inventory_hostname in groups['rke2_uninstall']

--- a/site.yml
+++ b/site.yml
@@ -11,3 +11,9 @@
   roles:
     - role: rke2_agent
   serial: 3
+
+- hosts: rke2_uninstall
+  become: yes
+  roles:
+    - role: rke2_uninstall
+  serial: 1


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:
While this playbook was originally written with the goal of simply bootstrapping a cluster of RKE2, its usage seems to have exceeded that.  This change allows for the usage of Ansible to remove nodes from a cluster and uninstalls RKE2 according to RKE2 documentation (https://docs.rke2.io/install/linux_uninstall/).

## Which issue(s) this PR fixes:
Fixes #16