### PR TITLE
Support an empty rke2_agents inventory group for RKE2 standalone deployments

### DIFF
--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -107,4 +107,4 @@
   when:
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists
-    - inventory_hostname in groups['rke2_agents'] | false
+    - inventory_hostname in groups['rke2_agents'] | default(false)

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -107,4 +107,4 @@
   when:
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists
-    - inventory_hostname in groups['rke2_agents'] | default(false)
+    - inventory_hostname in groups.get('rke2_agents', [])

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -107,4 +107,4 @@
   when:
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists
-    - inventory_hostname in groups['rke2_agents']
+    - inventory_hostname in groups['rke2_agents'] | false

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -168,7 +168,7 @@
     group: root
     remote_src: yes
   when:
-    - inventory_hostname in groups['rke2_agents'] | false
+    - inventory_hostname in groups['rke2_agents'] | default(false)
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
   copy:
@@ -179,7 +179,7 @@
     group: root
     remote_src: yes
   when:
-    - inventory_hostname in groups['rke2_agents'] | false
+    - inventory_hostname in groups['rke2_agents'] | default(false)
 
 - name: TARBALL | Refreshing systemd unit files
   systemd:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -168,7 +168,7 @@
     group: root
     remote_src: yes
   when:
-    - inventory_hostname in groups['rke2_agents']
+    - inventory_hostname in groups['rke2_agents'] | false
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
   copy:
@@ -179,7 +179,7 @@
     group: root
     remote_src: yes
   when:
-    - inventory_hostname in groups['rke2_agents']
+    - inventory_hostname in groups['rke2_agents'] | false
 
 - name: TARBALL | Refreshing systemd unit files
   systemd:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -168,7 +168,7 @@
     group: root
     remote_src: yes
   when:
-    - inventory_hostname in groups['rke2_agents'] | default(false)
+    - inventory_hostname in groups.get('rke2_agents', [])
 
 - name: TARBALL | Moving Systemd units to /etc/systemd/system
   copy:
@@ -179,7 +179,7 @@
     group: root
     remote_src: yes
   when:
-    - inventory_hostname in groups['rke2_agents'] | default(false)
+    - inventory_hostname in groups.get('rke2_agents', [])
 
 - name: TARBALL | Refreshing systemd unit files
   systemd:


### PR DESCRIPTION
Support an empty rke2_agents inventory group for RKE2 standalone deployments

## What type of PR is this?
- [X] feature

## What this PR does / why we need it:
I have been able to deploy an RKE2 standalone server by adding a single host to `[rke2_servers]` and **NO** hosts to `[rke2_agents]`. Due to the nature of the Ansible inventory that I am working with, I would like to remove the assumption that the `rke2_agents` inventory group is defined.

In particular, wherever we have `when` clauses like:
```
- inventory_hostname in groups['rke2_agents']
```

I would like to replace it with
```
- inventory_hostname in groups['rke2_agents'] | default(false)
```

This would not be required if it was possible to create an empty group at runtime, similar to `add_host`, but that does not seem to be possible.


## Which issue(s) this PR fixes:

Fixes #105 

## Testing

Manually, in my local environment

## Release Notes

```release-note
Support an empty rke2_agents inventory group for RKE2 standalone deployments
```