### PR TITLE
Start rke2-server for the first time with an empty config.yaml

### DIFF
--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -54,8 +54,6 @@
 
 - include: network_manager_fix.yaml
 
-- include: config.yml
-
 - name: Add server iptables rules
   include_tasks: iptables_rules.yml
   when:
@@ -73,3 +71,25 @@
   include_role:
     name: rke2_common
     tasks_from: cis-hardening
+
+# When starting the rke2-server service for the first time, and --profile=cis-1.5
+# or --profile=cis-1.6 is specified, the auto-generated TLS certificates will
+# have "startBefore" timestamps in the future which prevents the rke2-server service
+# from starting. For more information, see https://github.com/rancher/rke2/issues/1702
+- block:
+  - name: Start rke2-server to initialize TLS certificates
+    systemd:
+      name: rke2-server
+      state: started
+      enabled: yes
+
+  - name: Wait for k8s apiserver reachability
+    wait_for:
+      host: "{{ kubernetes_api_server_host }}"
+      port: "6443"
+      state: present
+      timeout: 300
+  when:
+    - ansible_facts.services["rke2-server.service"] is defined
+
+- include: config.yml


### PR DESCRIPTION
## What type of PR is this?
- [X ] bug

## What this PR does / why we need it:
When starting the rke2-server service for the first time, and --profile=cis-1.5 or --profile=cis-1.6 is specified, the auto-generated TLS certificates will have startBefore timestamps in the future which prevents the rke2-server service from starting. For more information, see https://github.com/rancher/rke2/issues/1702
    
As a workaround to this issue, the rke2-server service is started before the rke2_config values are persisted to config.yaml. Once the TLS certificates are initialized with an empty config.yaml, the rke2_config values are persisted and a second restart is applied.

## Which issue(s) this PR fixes:
No issue has been created

## Testing
Manually tested with the following configuration

```
rke2_config:
  profile: cis-1.6
```

## Release Notes
```release-note
Start rke2-server for the first time with an empty config.yaml to ensure valid startBefore timestamps in the auto-generated TLS certificates
```