### PR TITLE
fix: trigger rke2 restart when changing registry config

### DIFF
--- a/roles/rke2_agent/tasks/main.yml
+++ b/roles/rke2_agent/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: RKE2 agent and server tasks
+  vars:
+    caller_role_name: agent
   include_role:
     name: rke2_common
     tasks_from: main

--- a/roles/rke2_common/handlers/main.yml
+++ b/roles/rke2_common/handlers/main.yml
@@ -9,3 +9,8 @@
   service:
     state: restarted
     name: rke2-server
+
+- name: restart rke2-agent
+  service:
+    state: restarted
+    name: rke2-agent

--- a/roles/rke2_common/tasks/add-registry-config.yml
+++ b/roles/rke2_common/tasks/add-registry-config.yml
@@ -12,3 +12,15 @@
     mode: '0640'
     owner: root
     group: root
+  when: caller_role_name == "server" 
+  notify: restart rke2-server
+
+- name: Add registry configuration file
+  copy:
+    src: "{{ registry_config_file_path }}"
+    dest: "/etc/rancher/rke2/registries.yaml"
+    mode: '0640'
+    owner: root
+    group: root
+  when: caller_role_name == "agent" 
+  notify: restart rke2-agent

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: RKE2 agent and server tasks
+  vars:
+    caller_role_name: server
   include_role:
     name: rke2_common
     tasks_from: main


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

The goal of this PR is to make sure `rke2-{agent,server}` are restarted when a change is applied to the registry configuration.

## Which issue(s) this PR fixes:

I did not open an issue for this before submitting the PR, as the fix seemed quite easy. I can open an issue if you prefer.

## Special notes for your reviewer:

I was forced to duplicate the copy part to handle both agent and server cases, there might be a better way to do this. Do not hesitate to correct me if needed.

## Testing

Thanks for making these roles, we use them on our side.
We tested this change on our internal CI and were able to validate the expected behaviour.


