### PR TITLE
Added handling for unrecognized firewalld service failure

### DIFF
--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -50,7 +50,7 @@
     name: firewalld
     state: stopped
     enabled: no
-  when: ansible_facts.services["firewalld.service"] is defined
+  when: ansible_facts.services["firewalld.service"] is defined and ansible_facts.services["firewalld.service"].status != "not-found"
 
 - include: network_manager_fix.yaml
 

--- a/roles/rke2_server/tasks/other_servers.yml
+++ b/roles/rke2_server/tasks/other_servers.yml
@@ -58,7 +58,7 @@
     - name: Extract the hostname-override parameter from the kubelet process
       set_fact:
         kubelet_hostname_override_parameter: "{{ kubelet_check.stdout |\
-          regex_search('\\s--hostname-override=((([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
+          regex_search('\\s--hostname-override=((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
           '\\1') }}"
 
     - name: Wait for node to show Ready status


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

If a node has Docker installed, we run into an error where Ansible service facts collects the firewalld service since it is referred to as a dependency but actually isn't present on the machine. This means it is technically "defined" but any attempts to interact with the service will fail. This handling allows us to fail on any errors other than the service not being found, in which case we carry on (since firewalld is very much not running at that point). Confirmed working on Red Hat, Ubuntu and SLES.

## Which issue(s) this PR fixes:

Undocumented issue: when Docker is installed on the node, the following error is encountered when attempting the "disable FIREWALLD" task (log is from running on Ubuntu 18.04):
"failed: Could not find the requested service firewalld: host"

## Testing

Tested playbook on Ubuntu 18.04 node, and checked Ansible fact cache for supported OS distributions to make sure the status is "not-found".

## Release Notes

```release-note
Fixes issue where firewalld is defined in Ansible service facts if Docker is installed on the node due to a dependency, but the firewalld service is unrecognized/not found.
```

