### PR TITLE
add remote_user keyword as optional

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,7 @@ inventory  = ./inventory/my-cluster/hosts.ini
 remote_tmp = $HOME/.ansible/tmp
 local_tmp  = $HOME/.ansible/tmp
 pipelining = True
+#remote_user = root
 #become = True
 host_key_checking = False
 deprecation_warnings = False


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

- This is a small PR that adds the `remote_user` keyword to `ansible.cfg` as an optional configuration (it is commented out). It's useful to define this keyword when you are executing the playbook against remote targets where the RKE2 components will be deployed. 
  - https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html#play

## Which issue(s) this PR fixes:

- Fixes https://github.com/rancherfederal/rke2-ansible/issues/117

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Added `remote_user` keyword to ansible.cfg
```

