### PR TITLE
Handle tarball install after rke2-uninstall

### DIFF
--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -3,19 +3,27 @@
 - name: Check if rke2-server is previously installed
   ansible.builtin.debug:
     msg: "rke2-server is already installed. Skipping installation steps."
-  when: ansible_facts.services["rke2-server.service"] is defined
+  when: >
+    ansible_facts.services["rke2-server.service"] is defined
+    and not ansible_facts.services["rke2-server.service"].status == 'disabled'
 
 - name: Set fact if rke2-server was previously installed
   set_fact:
     installed: true
-  when: ansible_facts.services["rke2-server.service"] is defined
+  when: >
+    ansible_facts.services["rke2-server.service"] is defined
+    and not ansible_facts.services["rke2-server.service"].status == 'disabled'
 
 - name: Check if rke2-agent is previously installed
   ansible.builtin.debug:
     msg: "rke2-agent is already installed. Skipping installation steps."
-  when: ansible_facts.services["rke2-agent.service"] is defined
+  when: >
+    ansible_facts.services["rke2-agent.service"] is defined
+    and not ansible_facts.services["rke2-agent.service"].status == 'disabled'
 
 - name: Set fact if rke2-agent was previously installed
   set_fact:
     installed: true
-  when: ansible_facts.services["rke2-agent.service"] is defined
+  when: >
+    ansible_facts.services["rke2-agent.service"] is defined
+    and not ansible_facts.services["rke2-agent.service"].status == 'disabled'

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -16,10 +16,6 @@
     state: directory
     suffix: rke2-install.XXXXXXXXXX
   register: temp_dir
-  when:
-    - |-
-      ansible_facts.services["rke2-server.service"] is not defined or
-      ansible_facts.services["rke2-agent.service"] is not defined
 
 - name: Send provided tarball if available
   copy:


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [X] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

There is a problem re-installing after removing a cluster using `rke2-uninstall.sh`. Here are the reproduction steps:

1. `git clone https://github.com/aceeric/rke2-ansible.git esace-fork-rke2-ansible && cd esace-fork-rke2-ansible`
2. Provision a single `t3.xlarge` Centos 7 EC2 instance with SELinux disabled on the OS
3. Verify in the instance:
 ```
sh-4.2$ getenforce
Disabled
sh-4.2$ sestatus
SELinux status:                 disabled
 ```
4. Back on the ansible controller:
```
mkdir inventory/testme
cat <<EOF > inventory/testme/inventory.yaml
---
all:
  children:
    rke2_cluster:
      children:
        rke2_servers:
          hosts:
            10.114.174.40:
          vars:
            rke2_config:
              selinux: false
  vars:
    install_rke2_version: v1.25.6+rke2r1
EOF
```
5. Get binaries for tarball install:
```
export RKE2VER=v1.25.6 REL=rke2r1 BASE=https://github.com/rancher/rke2/releases/download &&\
curl -sfL $BASE/$RKE2VER%2B$REL/rke2-images.linux-amd64.tar.zst\
  -o ./tarball_install/rke2-images.linux-amd64.tar.zst &&\
  curl -sfL $BASE/$RKE2VER%2B$REL/rke2.linux-amd64.tar.gz\
  -o ./tarball_install/rke2.linux-amd64.tar.gz &&\
  curl -sfL $BASE/$RKE2VER%2B$REL/sha256sum-amd64.txt\
  -o ./tarball_install/sha256sum-amd64.txt
```
6. Perform the tarball install: `ansible-playbook -i inventory/testme site.yml`
7. After successful install, uninstall: `sudo /usr/local/bin/rke2-uninstall.sh`
8. Observe RKE2 service status:
```
sh-4.2$ sudo systemctl list-unit-files --all | grep 'UNIT\|rke2'
UNIT FILE                                     STATE
rke2-agent.service                            disabled
rke2-server.service                           disabled
```
9. If you now re-install, the "already installed" logic in the playbook that this PR modifies believes that RKE2 has already been installed and it won't copy the .ZST to the server. This causes problems in an air-gapped environment when a registry is not reachable - the result is image pull backoffs.

This PR determines whether RKE2 is installed based on the service state. If "disabled" then RKE2 is considered not to be installed.

## Which issue(s) this PR fixes:

I did't submit an issue for this.

## Testing

I tested the steps above both in an air-gapped enviroment and a connected environment. I encountered the issue without the change in the air-gapped environment and the change resolved the issue.