### PR TITLE
Restart NetworkManager

### DIFF
--- a/roles/rke2_common/tasks/network_manager_fix.yaml
+++ b/roles/rke2_common/tasks/network_manager_fix.yaml
@@ -39,3 +39,10 @@
     state: stopped
     enabled: no
   when: ansible_facts.services["nm-cloud-setup.service"] is defined
+
+- name: Reload NetworkManager
+  systemd:
+    name: NetworkManager
+    state: reloaded
+  when: (ansible_facts.services["NetworkManager.service"] is defined) and
+        (ansible_facts.services["NetworkManager.service"].status == "running")


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [X] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Described in: #137

## Which issue(s) this PR fixes:

Fixes #137

## Special notes for your reviewer:

n/a

## Testing

I've tested on CentOS 7 running the `network` service, and RHEL 7 running `NetworkManager` service and the change is benign in the first case and allows the install to succeed in the second.

## Release Notes

n/a
