### PR TITLE
Ignore failure when yum installing tar in a true airgapped env

### DIFF
--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -102,6 +102,7 @@
   package:
     name: tar
     state: present
+  ignore_errors: true
 
 - name: TARBALL | Extract the tarball  # noqa command-instead-of-module
   command:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [X] bug
- [X] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

It's debatable whether this is a bug, cleanup, or feature. The `rke2_common` role `tarball_install` task is only invoked when the binaries are staged. This is our scenario for a *fully air-gapped* install. In a true air-gapped install, a yum repository server is not accessible. Yet the task `yum installs tar`. Unfortunately this initiates the yum metadata / caching functionality. Of course this can all be configured / overridden / etc. But - what we're encountering is this statement...
```
- name: TARBALL | Install tar package
  package:
    name: tar
    state: present
```
...fails because there's no network-accessible yum repository server to sync metadata from. This PR simply ignores the error because the very next statement invokes the tar command which - if tar isn't already installed and the yum install tar fails - the task still fails: the net effect is identical So the addition from this PR prevents the playbook from failing in a fully disconnected environment without a lot of yum configuration, and supports the intent of the original mod to add tar if it's missing, and fails if there is any actual issue with tar just like before the PR.

## Which issue(s) this PR fixes:

I did not submit an issue.

## Special notes for your reviewer:

## Testing

Tested in an airgapped environment with tar already installed.

## Release Notes

This should not affect users. If tar isn't installed, and can't be installed, the playbook fails before and after the PR. If tar is already installed, the playbook succeeds before and after the PR even in an air-gapped environment
