### PR TITLE
Support tarball upgrade

### DIFF
--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -259,20 +259,20 @@
     state: absent
   changed_when: false
 
-- name: Restart rke2-server if package installed and config changed
+- name: Restart rke2-server if package installed and config changed or RKE2 version changed
   service:
     state: restarted
     name: rke2-server
   when:
     - ansible_facts.services["rke2-server.service"] is defined
     - "ansible_facts.services['rke2-server.service'].state == 'running'"
-    - tmp_sha1 != previous_rke2_config.stat.checksum
+    - (tmp_sha1 != previous_rke2_config.stat.checksum or (rke2_version_changed | default(false)))
 
-- name: Restart rke2-agent if package installed and config changed
+- name: Restart rke2-agent if package installed and config changed or RKE2 version changed
   service:
     state: restarted
     name: rke2-agent
   when:
     - ansible_facts.services["rke2-agent.service"] is defined
     - "ansible_facts.services['rke2-agent.service'].state == 'running'"
-    - tmp_sha1 != previous_rke2_config.stat.checksum
+    - (tmp_sha1 != previous_rke2_config.stat.checksum or (rke2_version_changed | default(false)))

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -12,7 +12,6 @@
 
 - name: Include images_tarball_install.yml
   include_tasks: images_tarball_install.yml
-  when: not installed
 
 - name: "Check for binary tarball in {{ playbook_dir }}/tarball_install/rke2.linux-amd64.tar.gz"  # noqa name[template]
   stat:
@@ -21,6 +20,26 @@
   delegate_to: 127.0.0.1
   become: no
 
+- name: Check for the rke2 binary
+  stat:
+    path: /usr/local/bin/rke2
+  register: rke2_binary
+
+- name: If the rke2 binary exists, determine if the version is changing
+  when: rke2_binary.stat.exists
+  block:
+    - name: Get current RKE2 version
+      shell: set -o pipefail && /usr/local/bin/rke2 -v | head -n 1 | cut -d ' ' -f 3
+      register: installed_rke2_version
+      changed_when: false
+      args:
+        executable: /usr/bin/bash
+
+    - name: Determine if current version differs what what is being installed
+      set_fact:
+        rke2_version_changed: true
+      when: "'stdout' in installed_rke2_version and installed_rke2_version['stdout'] != install_rke2_version"
+
 - name: SLES/Ubuntu/Tarball Installation
   include_tasks: tarball_install.yml
   when:
@@ -28,7 +47,6 @@
       ((ansible_facts['os_family'] != 'RedHat' and
       ansible_facts['os_family'] != 'Rocky') or
       rke2_binary_tarball_check.stat.exists )
-      and not installed
 
 - name: RHEL/CentOS Installation
   when:


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:
This PR supports upgrading (and downgrading) RKE2 via the tarball method. It is informed by work done in [this ticket](https://github.com/rancherfederal/rke2-ansible/issues/126).

The Rancher Federal Ansible already supports upgrading a cluster using the RPM method. But for some reason it prevents this in the tarball method. The PR simply enables the tarball method to achieve consistency with the RPM method. (It also supports downgrading via tarball because that comes along with the change for free but that's not really the goal.) This branch takes a minimalist approach: It will do what you tell it. It doesn't try to protect the person installer from doing wrong things, such as upgrading Kubernetes in a disallowed way. I made this choice because the converse would require codifying logic in Ansible that fundamentally is owned by the k8s maintainers.

## Which issue(s) this PR fixes:

#154

## Special notes for your reviewer:

N/A

## Testing

I have tested the following scenarios in AWS :

ONE: With a two-instance cluster consisting of one controller and one worker and after each step the resulting cluster version matched the install version.

Airgap install: v1.25.11+rke2r1
Airgap install: v1.25.13+rke2r1
Airgap install: v1.25.11+rke2r1
Uninstall
Airgap install: v1.25.11+rke2r1
Airgap install: v1.25.11+rke2r1

TWO: Tested the same scenarios above with the RPM install method to ensure the changes didn't affect the RPM path:

RPM install: v1.25.11+rke2r1
RPM install: v1.25.13+rke2r1
RPM install: v1.25.11+rke2r1

The RPM _downgrade_ to `v1.25.11+rke2r1` was ignored by the Ansible. This was consistent with the pre-PR behavior, and so I stopped here for the RPM testing, satisfying myself that I had not impacted the RPM behavior.

THREE: Tested one scenario with an H/A cluster consisting of 3 control plane instances and 2 workers:

Airgap install v1.25.11+rke2r1
Airgap install v1.25.13+rke2r1

## Release Notes

```release-note
NONE
```

