### PR TITLE
fix: support install_rke2_version param for ubuntu

### DIFF
--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -45,8 +45,12 @@
       args:
         executable: /bin/bash
 
+    - name: Set rke2_full_version fact  # noqa var-spacing
+      set_fact:
+        rke2_full_version: "{{ rke2_full_version.stdout if ((install_rke2_version is not defined) or (install_rke2_version|length == 0)) else install_rke2_version }}"  # yamllint disable-line rule:line-length
+
     - name: Set dot version
-      shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /usr/bin/cut -d'+' -f1
+      shell: set -o pipefail && echo {{ rke2_full_version }} | /usr/bin/cut -d'+' -f1
       register: rke2_version_dot
       changed_when: false
       args:
@@ -54,7 +58,7 @@
 
     - name: Set Maj.Min version
       shell: >-
-        set -o pipefail && echo {{ rke2_full_version.stdout }}
+        set -o pipefail && echo {{ rke2_full_version }}
         | awk -F'.' '{ print $1"."$2 }' | sed "s|^v||g"
       register: rke2_version
       changed_when: false
@@ -64,14 +68,14 @@
     - name: Describe versions
       debug:
         msg:
-          - "Full version: {{ rke2_full_version.stdout }}"
+          - "Full version: {{ rke2_full_version }}"
           - "dot version: {{ rke2_version_dot.stdout }}"
           - "Maj.Min version: {{ rke2_version.stdout }}"
       run_once: yes
 
     - name: TARBALL | Download the tarball
       get_url:
-        url: https://github.com/rancher/rke2/releases/download/{{ rke2_full_version.stdout }}/rke2.linux-amd64.tar.gz
+        url: https://github.com/rancher/rke2/releases/download/{{ rke2_full_version }}/rke2.linux-amd64.tar.gz
         dest: "{{ temp_dir.path }}/rke2.linux-amd64.tar.gz"
         mode: "0644"
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Before this small change *install_rke2_version* was ignored for non RH/Rocky.

## Which issue(s) this PR fixes:

No listed issue as I've seen.  

## Special notes for your reviewer:

Change is very simple.

## Testing

- Run playbook with declared var *install_rke2_version* and without it on my ubuntu 20.04 farm.

## Release Notes

```release-note
Stops ignoring install_rke2_version for non RH based machines. 
```

