### PR TITLE
Do not create etcd home directory (#158)

### DIFF
--- a/roles/rke2_common/tasks/cis-hardening.yml
+++ b/roles/rke2_common/tasks/cis-hardening.yml
@@ -15,6 +15,7 @@
         comment: etcd user
         shell: /bin/nologin
         group: etcd
+        create_home: false
 
     - name: Copy systemctl file for kernel hardening for yum installs
       copy:


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

As part of the CIS hardening tasks, when `/home` is an NFS volume and root squashing is enabled, and Ansible (as root) tries to `mkdir /home/etcd` it results in an OS error. If the person installer doesn't have the ability to change this NFS configuration on the underlying hosts then the installation fails.

This PR omits creation of the home directory for the `etcd` user.

## Which issue(s) this PR fixes:

Closes #158

## Special notes for your reviewer:

N/A

## Testing

Tested the change with `/home` both as an NFS mount with root squashing and also as a local directory.

## Release Notes

```release-note
Omit creation of the etcd home directory as part of CIS hardening in case /home is an NFS mount with root squashing enabled.
```