### PR TITLE
Obtain rke2 version without bash pipe failure

### DIFF
--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -34,7 +34,7 @@
   register: rke2_binary
 
 - name: Get current RKE2 version if already installed
-  ansible.builtin.shell: set -o pipefail && /usr/local/bin/rke2 -v | head -n 1 | cut -d ' ' -f 3
+  ansible.builtin.shell: set -o pipefail && /usr/local/bin/rke2 -v | awk '$1 ~ /rke2/ { print $3 }'
   register: installed_rke2_version_tmp
   changed_when: false
   args:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -57,7 +57,7 @@
         remote_src: true
 
     - name: Get tarball RKE2 version from temp location
-      ansible.builtin.shell: set -o pipefail && {{ temp_dir.path }}/bin/rke2 -v | head -n 1 | cut -d ' ' -f 3
+      ansible.builtin.shell: set -o pipefail && {{ temp_dir.path }}/bin/rke2 -v | awk '$1 ~ /rke2/ { print $3 }'
       register: tarball_rke2_version_tmp
       changed_when: false
       args:


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [X] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

The rke2 version check fails on a bash pipe, stopping the entire playbook. Issue is known to exist for rke2 installs to Rocky9 and Ubuntu 22.04.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes #167

## Testing

Code successfully tested install of rke2 tarball install to Rocky 9.2 cluster.

<!--
  Describe how you tested this change.
-->

## Release Notes

Obtain rke2 version without bash pipe failure
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```

