### PR TITLE
Parameterized temp dir used during a tarball install.

### DIFF
--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -15,6 +15,7 @@
   ansible.builtin.tempfile:
     state: directory
     suffix: rke2-install.XXXXXXXXXX
+    path: "{{ tarball_tmp_dir | default(omit) }}"
   register: temp_dir
 
 - name: Send provided tarball if available


### PR DESCRIPTION
## What type of PR is this?


- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

During a tarball install the rke2 executable will be run from a temporary directory created in the system default temp directroy (usually `/tmp`), which means the install will fail when `/tmp` is mounted with the `noexec` option. 

This PR parameterizes the path to the parent directory of the temporary directory that gets created by adding the `tarball_temp_dir` variable, while leaving it to the system default if `tarball_temp_dir` is not specified.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes #172 
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

N/A

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Tested performing tarball installs with `tarball_temp_dir` undefined and defined to point to a path other than the system default temp dir.

<!--
  Describe how you tested this change.
-->

## Release Notes

`Parameterized tmp dir used during a tarball install.`
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

