### PR TITLE
Fix #169 -- add systemd env options

### DIFF
--- a/inventory/sample/group_vars/rke2_agents.yml
+++ b/inventory/sample/group_vars/rke2_agents.yml
@@ -8,3 +8,10 @@ rke2_config: {}
 # See https://docs.rke2.io/install/containerd_registry_configuration/
 # Add a registry configuration file by specifying the file path on the control host
 # registry_config_file_path: "{{ playbook_dir }}/sample_files/registries.yaml"
+
+# See https://docs.rke2.io/advanced#configuring-an-http-proxy
+# Add proxy information for the systemd environment
+# systemd-extra-env:
+# #- HTTP_PROXY=http://your-proxy.example.com:8888
+# #- HTTPS_PROXY=http://your-proxy.example.com:8888
+# #- NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/inventory/sample/group_vars/rke2_servers.yml
+++ b/inventory/sample/group_vars/rke2_servers.yml
@@ -45,3 +45,10 @@ rke2_config: {}
 # See https://docs.rke2.io/helm/#automatically-deploying-manifests-and-helm-charts
 # Add manifest files by specifying the directory path on the control host
 # manifest_config_file_path: "{{ playbook_dir }}/sample_files/manifest/"
+
+# See https://docs.rke2.io/advanced#configuring-an-http-proxy
+# Add proxy information for the systemd environment
+# systemd-extra-env:
+# #- HTTP_PROXY=http://your-proxy.example.com:8888
+# #- HTTPS_PROXY=http://your-proxy.example.com:8888
+# #- NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -21,3 +21,5 @@ rke2_versioned_yum_repo:
   enabled: yes
 
 rke2_config: {}
+
+systemd_extra_env: {}

--- a/roles/rke2_common/tasks/add-systemd-env.yml
+++ b/roles/rke2_common/tasks/add-systemd-env.yml
@@ -1,0 +1,21 @@
+---
+- name: Systemd env file
+  become: true
+  when: (systemd_extra_env is defined) and (systemd_extra_env|length > 0)
+  block:
+
+    - name: Add the systemd env file
+      ansible.builtin.blockinfile:
+        path: /etc/default/rke2-{{ caller_role_name }}
+        marker: "#{mark} ANSIBLE MANAGED FILE"
+        create: true
+        mode: '640'
+        owner: root
+        group: root
+        block: |
+          {% for item in systemd_extra_env %}
+          {{ item }}
+          {% endfor %}
+    - name: Reload the systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -70,6 +70,10 @@
   ansible.builtin.include_tasks: add-registry-config.yml
   when: registry_config_file_path | length > 0
 
+- name: Include task file add-systemd-env.yml
+  ansible.builtin.include_tasks: add-systemd-env.yml
+  when: systemd_extra_env | length > 0
+
 - name: Run CIS-Hardening Tasks
   ansible.builtin.include_role:
     name: rke2_common


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [ X] feature

## What this PR does / why we need it:
It adds the optional ability to add and configure an rke-{server,agent} systemd environment file to /etc/default

## Which issue(s) this PR fixes:

Fixes #169 


## Release Notes

```release-note
Add the ability to optionally create an /etc/default/rke-{server,agent} file to configure the systemd file for proxy information.
```

