### PR TITLE
Fix #175 support RHEL 9 family installation including Rocky Linux 9

### DIFF
--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -18,7 +18,7 @@
   when:
     - not stat_rke2_common_repo.stat.exists
     - ansible_facts['os_family'] == "RedHat" or ansible_facts['os_family'] == "Rocky"
-    - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "8"
+    - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "8" or ansible_facts['distribution_major_version'] == "9"
 
 # Does the Rancher RKE2 versioned repo exist already
 - name: Check to see if rke2 versioned repo exists
@@ -38,7 +38,7 @@
   when:
     - not stat_rke2_common_repo.stat.exists
     - ansible_facts['os_family'] == "RedHat" or ansible_facts['os_family'] == "Rocky"
-    - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "8"
+    - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "8" or ansible_facts['distribution_major_version'] == "9"
 
 - name: YUM-Based | Install rke2-server
   ansible.builtin.yum:


### PR DESCRIPTION
This PR adds support for RHEL 9 family operating systems

## What type of PR is this?



- [ ] bug
- [ ] cleanup
- [ ] documentation
- [ X] feature


## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #175 



## Release Notes



```Adds an update to support RHEL 9 family installation including Rocky 9

```

