### PR TITLE
Fix repos names to align with uninstall script

### DIFF
--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -5,7 +5,7 @@ audit_policy_config_file_path: ""
 registry_config_file_path: ""
 add_iptables_rules: false
 rke2_common_yum_repo:
-  name: rke2-common
+  name: rancher-rke2-common
   description: "Rancher RKE2 Common Latest"
   baseurl: "https://rpm.rancher.io/rke2/latest/common/centos/$releasever/noarch"
   gpgcheck: true
@@ -13,7 +13,7 @@ rke2_common_yum_repo:
   enabled: yes
 
 rke2_versioned_yum_repo:
-  name: "rke2-v{{ rke2_version_majmin }}"  # noqa jinja[spacing]
+  name: "rancher-rke2-v{{ rke2_version_majmin }}"  # noqa jinja[spacing]
   description: "Rancher RKE2 Version"
   baseurl: "https://rpm.rancher.io/rke2/latest/{{ rke2_version_majmin }}/centos/$releasever/$basearch"
   gpgcheck: true


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:
The uninstall scripts that are included with RKE2 specifically look for yum repos `/etc/yum.repos.d/rancher-rke2*.repo`. Currently the ansible role creates repos that are missing `rancher-`. This causes the uninstall script to not delete the repo files. If you then try to install RKE2 again with a different version, it will fail because there are multiple yum repos defined. The ansible roles should name the repos correctly.


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:
Fixes #178 

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->


## Testing
Install RKE2 using the ansible. Run `rke2-uninstall.sh`. Repos in `/etc/yum.repos.d` deleted.
<!--
  Describe how you tested this change.
-->

## Release Notes
_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Yum repos renamed to be prefixed with `rancher-` to align with rke2-uninstall script
```

