### PR TITLE
Add pod security admission config

### DIFF
--- a/inventory/sample/group_vars/rke2_servers.yml
+++ b/inventory/sample/group_vars/rke2_servers.yml
@@ -45,3 +45,8 @@ rke2_config: {}
 # See https://docs.rke2.io/helm/#automatically-deploying-manifests-and-helm-charts
 # Add manifest files by specifying the directory path on the control host
 # manifest_config_file_path: "{{ playbook_dir }}/sample_files/manifest/"
+
+# See https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces
+# Available in RKE2 1.25+
+# Add a pod security admission config file by specifying the file path on the control host
+# pod_security_admission_config_file_path: "{{ playbook_dir }}/sample_files/pod-security-admission-config.yaml"

--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -3,6 +3,7 @@ tarball_dir: "/usr/local"
 rke2_channel: stable
 audit_policy_config_file_path: ""
 registry_config_file_path: ""
+pod_security_admission_config_file_path: ""
 add_iptables_rules: false
 rke2_common_yum_repo:
   name: rke2-common

--- a/roles/rke2_common/tasks/add-pod-security-admission-config.yml
+++ b/roles/rke2_common/tasks/add-pod-security-admission-config.yml
@@ -1,0 +1,16 @@
+---
+- name: Create the /etc/rancher/rke2 config dir
+  ansible.builtin.file:
+    path: /etc/rancher/rke2
+    state: directory
+    recurse: yes
+
+- name: Add pod security admission config file
+  ansible.builtin.copy:
+    src: "{{ pod_security_admission_config_file_path }}"
+    dest: "/etc/rancher/rke2/pod-security-admission-config.yaml"
+    mode: '0640'
+    owner: root
+    group: root
+  when: caller_role_name == "server"
+  notify: Restart rke2-server

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -70,6 +70,10 @@
   ansible.builtin.include_tasks: add-registry-config.yml
   when: registry_config_file_path | length > 0
 
+- name: Include task file add-pod-security-admission-config.yml
+  ansible.builtin.include_tasks: add-pod-security-admission-config.yml
+  when: pod_security_admission_config_file_path | length > 0
+
 - name: Run CIS-Hardening Tasks
   ansible.builtin.include_role:
     name: rke2_common

--- a/sample_files/pod-security-admission-config.yaml
+++ b/sample_files/pod-security-admission-config.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: PodSecurity
+    configuration:
+      apiVersion: pod-security.admission.config.k8s.io/v1
+      kind: PodSecurityConfiguration
+      defaults:
+        enforce: "restricted"
+        enforce-version: "latest"
+        audit: "restricted"
+        audit-version: "latest"
+        warn: "restricted"
+        warn-version: "latest"
+      exemptions:
+        usernames: []
+        runtimeClasses: []
+        namespaces: [calico-apiserver,
+                     calico-system,
+                     cattle-alerting,
+                     cattle-csp-adapter-system,
+                     cattle-elemental-system,
+                     cattle-epinio-system,
+                     cattle-externalip-system,
+                     cattle-fleet-local-system,
+                     cattle-fleet-system,
+                     cattle-gatekeeper-system,
+                     cattle-global-data,
+                     cattle-global-nt,
+                     cattle-impersonation-system,
+                     cattle-istio,
+                     cattle-istio-system,
+                     cattle-logging,
+                     cattle-logging-system,
+                     cattle-monitoring-system,
+                     cattle-neuvector-system,
+                     cattle-prometheus,
+                     cattle-provisioning-capi-system,
+                     cattle-resources-system,
+                     cattle-sriov-system,
+                     cattle-system,
+                     cattle-ui-plugin-system,
+                     cattle-windows-gmsa-system,
+                     cert-manager,
+                     cis-operator-system,
+                     fleet-default,
+                     ingress-nginx,
+                     istio-system,
+                     kube-node-lease,
+                     kube-public,
+                     kube-system,
+                     longhorn-system,
+                     local-path-storage,
+                     rancher-alerting-drivers,
+                     security-scan,
+                     tigera-operator]


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

Adds the pod security admission config file for Kubernetes 1.25+. With the removal of pod security policy in 1.25, it is necessary to override the [pod security admission controller configuration](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces) on hardened clusters to make Rancher MCM or any rancher addon function properly. This file is only necessary on the server nodes.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:
Closed #149

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Add pod security admission config file override functionality.
```

