### PR TITLE
updating reboot logic to minimize the chance of an unnecessary reboot

### DIFF
--- a/roles/rke2_common/tasks/cis-hardening.yml
+++ b/roles/rke2_common/tasks/cis-hardening.yml
@@ -46,7 +46,10 @@
         name: systemd-sysctl
       when: sysctl_operation_yum.changed or sysctl_operation_tarball.changed
 
+    # Per CIS hardening guide, if Kubernetes is already running, making changes to sysctl can result in unexpected
+    # side-effects. Rebooting node if RKE2 is already running to prevent potential issues whereas before we were
+    # always rebooting, even if the node was brand new and RKE2 not running yet.
     - name: Reboot the machine (Wait for 5 min)
       ansible.builtin.reboot:
         reboot_timeout: 300
-      when: sysctl_operation_yum.changed or sysctl_operation_tarball.changed
+      when: (sysctl_operation_yum.changed or sysctl_operation_tarball.changed) and rke2_running is defined and rke2_running

--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -14,6 +14,13 @@
     ansible_facts.services["rke2-server.service"] is defined
     and not ansible_facts.services["rke2-server.service"].status == 'disabled'
 
+- name: Set fact if rke2-server is running
+  ansible.builtin.set_fact:
+    rke2_running: true
+  when: >
+    ansible_facts.services["rke2-server.service"] is defined
+    and ansible_facts.services["rke2-server.service"].state == 'running'
+
 - name: Check if rke2-agent is previously installed
   ansible.builtin.debug:
     msg: "rke2-agent is already installed. Skipping installation steps."
@@ -27,6 +34,13 @@
   when: >
     ansible_facts.services["rke2-agent.service"] is defined
     and not ansible_facts.services["rke2-agent.service"].status == 'disabled'
+
+- name: Set fact if rke2-agent is running
+  ansible.builtin.set_fact:
+    rke2_running: true
+  when: >
+    ansible_facts.services["rke2-agent.service"] is defined
+    and ansible_facts.services["rke2-agent.service"].state == 'running'
 
 - name: Check for the rke2 binary
   ansible.builtin.stat:


### PR DESCRIPTION
Existing code would reboot a server at install time due to sysctl changes. It turns out that a reboot is only necessary if RKE2 is already running.

## What type of PR is this?

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Updates the reboot logic to check to see if RKE2 is running. If it is, and sysctl updates, reboot the host. Otherwise just restart sysctl.

## Which issue(s) this PR fixes:

Fixes #199 

## Release Notes

NONE

