### PR TITLE
removing unnecessary code

### DIFF
--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -14,13 +14,6 @@
     ansible_facts.services["rke2-server.service"] is defined
     and ansible_facts.services["rke2-server.service"].state == 'running'
 
-- name: Check if rke2-agent is previously installed
-  ansible.builtin.debug:
-    msg: "rke2-agent is already installed. Skipping installation steps."
-  when: >
-    ansible_facts.services["rke2-agent.service"] is defined
-    and not ansible_facts.services["rke2-agent.service"].status == 'disabled'
-
 - name: Set fact if rke2-agent was previously installed
   ansible.builtin.set_fact:
     installed: true

--- a/roles/rke2_common/tasks/previous_install.yml
+++ b/roles/rke2_common/tasks/previous_install.yml
@@ -1,12 +1,5 @@
 ---
 
-- name: Check if rke2-server is previously installed
-  ansible.builtin.debug:
-    msg: "rke2-server is already installed. Skipping installation steps."
-  when: >
-    ansible_facts.services["rke2-server.service"] is defined
-    and not ansible_facts.services["rke2-server.service"].status == 'disabled'
-
 - name: Set fact if rke2-server was previously installed
   ansible.builtin.set_fact:
     installed: true


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [x] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

Removes an unneeded debug message about skipping installation if RKE2 is already installed.- since we support doing upgrades, this is invalid.

## Which issue(s) this PR fixes:

Fixes #201 

## Release Notes

NONE

