### PR TITLE
#213 Render templated variables within rke2_config prior to updating

### DIFF
--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -36,6 +36,11 @@
     group: root
   when: not previous_rke2_config.stat.exists
 
+# https://github.com/ansible-collections/ansible.utils/issues/135
+- name: Ensure Ansible renders any templated variables in rke2_config
+  ansible.builtin.set_fact:
+    rke2_config: "{{ rke2_config | default({}) }}"
+
 # --node-label value                     (agent/node) Registering and starting kubelet with set of labels
 
 - name: Get rke2_config node-labels


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

This PR address #213 - specifically, any templated variables within the `rke2_config` variable will not be rendered correctly when written to the `config.yaml` file. Based on the [known issue when using `update_fact`](https://github.com/ansible-collections/ansible.utils/issues/135), the best solution is to use `set_fact` to render all templated variables.

## Which issue(s) this PR fixes:

Fixes #213

## Testing

I performed two tests, each with the following `rke2_config`:

```
selinux: true
rke2_config:
  selinux: "{{ selinux_enabled }}"
```

- Test 1: using `main` branch
  - Result: Failure - the `config.yaml` contained:
    ```
    selinux: \"\{\{ selinux_enabled \}\}\" 
    ```
    - the `rke2-server` service failed to start

- Test 2: using the branch in this PR
  - Result: Success - the `config.yaml` contained:
    ```
    selinux: true
    ```
    - the `rke2-server` service started successfully

## Release Notes

None

