### PR TITLE
updating etcd nologin

### DIFF
--- a/roles/rke2_common/tasks/cis-hardening.yml
+++ b/roles/rke2_common/tasks/cis-hardening.yml
@@ -13,7 +13,7 @@
       ansible.builtin.user:
         name: etcd
         comment: etcd user
-        shell: /bin/nologin
+        shell: /usr/sbin/nologin
         group: etcd
         create_home: false
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [X] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

nologin path was incorrect


## Which issue(s) this PR fixes:

Fixes #102 

## Release Notes

```release-note
Fixing incorrect nologin path
```

