### PR TITLE
219 automate the configuration of kubectlctrcri

### DIFF
--- a/inventory/sample/group_vars/rke2_servers.yml
+++ b/inventory/sample/group_vars/rke2_servers.yml
@@ -45,3 +45,11 @@ rke2_config: {}
 # See https://docs.rke2.io/helm/#automatically-deploying-manifests-and-helm-charts
 # Add manifest files by specifying the directory path on the control host
 # manifest_config_file_path: "{{ playbook_dir }}/sample_files/manifest/"
+
+# Configure RKE2 utilites such as kubectl, ctr, and crictl via symlinks.
+# configure_utilities: true
+
+# If configure_utilites, and you want Helm installed
+# helm_url: https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz
+# or
+# helm_binary_path: /path/to/helm

--- a/inventory/sample/group_vars/rke2_servers.yml
+++ b/inventory/sample/group_vars/rke2_servers.yml
@@ -45,11 +45,3 @@ rke2_config: {}
 # See https://docs.rke2.io/helm/#automatically-deploying-manifests-and-helm-charts
 # Add manifest files by specifying the directory path on the control host
 # manifest_config_file_path: "{{ playbook_dir }}/sample_files/manifest/"
-
-# Configure RKE2 utilites such as kubectl, ctr, and crictl via symlinks.
-# configure_utilities: true
-
-# If configure_utilites, and you want Helm installed
-# helm_url: https://get.helm.sh/helm-v3.15.0-linux-amd64.tar.gz
-# or
-# helm_binary_path: /path/to/helm

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -17,4 +17,3 @@
 
 - name: Configure Utilities
   ansible.builtin.include_tasks: utilities.yml
-  when: configure_utilites | bool

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -18,3 +18,4 @@
 - name: Configure Utilities
   ansible.builtin.include_tasks: utilities.yml
   when: configure_utilites | bool
+  

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -18,4 +18,3 @@
 - name: Configure Utilities
   ansible.builtin.include_tasks: utilities.yml
   when: configure_utilites | bool
-  

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -1,16 +1,20 @@
 ---
 
-- name: RKE2 agent and server tasks
-  vars:
-    rke2_common_caller_role_name: server
-  ansible.builtin.include_role:
-    name: rke2_common
-    tasks_from: main
+# - name: RKE2 agent and server tasks
+#   vars:
+#     rke2_common_caller_role_name: server
+#   ansible.builtin.include_role:
+#     name: rke2_common
+#     tasks_from: main
 
-- name: Setup initial server
-  ansible.builtin.include_tasks: first_server.yml
-  when: inventory_hostname in groups['rke2_servers'][0]
+# - name: Setup initial server
+#   ansible.builtin.include_tasks: first_server.yml
+#   when: inventory_hostname in groups['rke2_servers'][0]
 
-- name: Setup other servers
-  ansible.builtin.include_tasks: other_servers.yml
-  when: inventory_hostname in groups['rke2_servers'][1:]
+# - name: Setup other servers
+#   ansible.builtin.include_tasks: other_servers.yml
+#   when: inventory_hostname in groups['rke2_servers'][1:]
+
+- name: Configure Utilities
+  ansible.builtin.include_tasks: utilities.yml
+  when: configure_utilites | bool

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 
-# - name: RKE2 agent and server tasks
-#   vars:
-#     rke2_common_caller_role_name: server
-#   ansible.builtin.include_role:
-#     name: rke2_common
-#     tasks_from: main
+- name: RKE2 agent and server tasks
+  vars:
+    rke2_common_caller_role_name: server
+  ansible.builtin.include_role:
+    name: rke2_common
+    tasks_from: main
 
-# - name: Setup initial server
-#   ansible.builtin.include_tasks: first_server.yml
-#   when: inventory_hostname in groups['rke2_servers'][0]
+- name: Setup initial server
+  ansible.builtin.include_tasks: first_server.yml
+  when: inventory_hostname in groups['rke2_servers'][0]
 
-# - name: Setup other servers
-#   ansible.builtin.include_tasks: other_servers.yml
-#   when: inventory_hostname in groups['rke2_servers'][1:]
+- name: Setup other servers
+  ansible.builtin.include_tasks: other_servers.yml
+  when: inventory_hostname in groups['rke2_servers'][1:]
 
 - name: Configure Utilities
   ansible.builtin.include_tasks: utilities.yml

--- a/roles/rke2_server/tasks/utilities.yml
+++ b/roles/rke2_server/tasks/utilities.yml
@@ -1,82 +1,24 @@
-# - name: Symlink crictl to /usr/local/bin
-#   ansible.builtin.file:
-#     src: "/var/lib/rancher/rke2/bin/crictl"
-#     dest: "/usr/local/bin/crictl"
-#     state: link
+- name: Add /var/lib/rancher/rke2/bin to PATH
+  lineinfile:
+    dest: "/root/.bashrc"
+    line: 'PATH=$PATH:/var/lib/rancher/rke2/bin'
+    insertafter: EOF
 
-# - name: Symlink crictl config to /etc/crictl.yaml
-#   ansible.builtin.file:
-#     src: "/var/lib/rancher/rke2/agent/etc/crictl.yaml"
-#     dest: "/etc/crictl.yaml"
-#     state: link
-
-# - name: Symlink ctr to /usr/local/bin
-#   ansible.builtin.file:
-#     src: "/var/lib/rancher/rke2/bin/ctr"
-#     dest: "/usr/local/bin/ctr"
-#     state: link
-  
-# - name: Symlink kubectl to /usr/local/bin
-#   ansible.builtin.file:
-#     src: "/var/lib/rancher/rke2/bin/kubectl"
-#     dest: "/usr/local/bin/kubectl"
-#     state: link
-  
-# - name: Create .kube directory in /root
-#   ansible.builtin.file:
-#     path: /root/.kube
-#     state: directory
-#     mode: '0750'
-
-# - name: Symlink kubectl config to /root/.kube/config
-#   ansible.builtin.file:
-#     src: "/etc/rancher/rke2/rke2.yaml"
-#     dest: "/root/.kube/config"
-#     state: link
-
-# - name: Check if Helm is installed
-#   stat:
-#     path: "/usr/local/bin/helm"
-#   register: helm_installed
-#   when: 
-#      - helm_tar_url is defined
-#      - helm_tar_url | length > 0
-
-# - name: Get Helm version
-#   command: "/usr/local/bin/helm version"
-#   changed_when: false
-#   register: helm_installed_version
-#   when: helm_installed.stat.exists
-
-- name: Install Helm Tar from URL
-  ansible.builtin.unarchive:
-    remote_src: yes #allow file to be pulled via https
-    src: "{{ helm_tar_url }}"
-    dest: "/usr/local/bin"
-    extra_opts:
-      - --strip=1
-      - --wildcards
-      - '*/helm'
-  when: 
-    # - not helm_installed.stat.exists
-    - helm_tar_url is defined
-    - helm_tar_url | length > 0
-
-- name: Install Helm Binary from file
-  ansible.builtin.copy:
-    src: "{{ helm_binary_path }}"
-    dest: "/usr/local/bin/helm"
-  when:
-    - helm_binary_path is defined
-    - helm_binary_path | length > 0
-
-- name: Set Helm permissions
+- name: Symlink crictl config to /etc/crictl.yaml
   ansible.builtin.file:
-    path: /usr/local/bin/helm
-    owner: root
-    group: root
-    mode: '0755'
-  when:
-    - (helm_tar_url is defined and helm_tar_url | length > 0) or
-      (helm_binary_path is defined and helm_binary_path | length > 0)
+    src: "/var/lib/rancher/rke2/agent/etc/crictl.yaml"
+    dest: "/etc/crictl.yaml"
+    state: link
+  
+- name: Create .kube directory in /root
+  ansible.builtin.file:
+    path: /root/.kube
+    state: directory
+    mode: '0750'
+
+- name: Symlink kubectl config to /root/.kube/config
+  ansible.builtin.file:
+    src: "/var/lib/rancher/rke2/server/cred/admin.kubeconfig"
+    dest: "/root/.kube/config"
+    state: link
   

--- a/roles/rke2_server/tasks/utilities.yml
+++ b/roles/rke2_server/tasks/utilities.yml
@@ -9,7 +9,7 @@
     src: "/var/lib/rancher/rke2/agent/etc/crictl.yaml"
     dest: "/etc/crictl.yaml"
     state: link
-  
+
 - name: Create .kube directory in /root
   ansible.builtin.file:
     path: /root/.kube
@@ -21,4 +21,3 @@
     src: "/var/lib/rancher/rke2/server/cred/admin.kubeconfig"
     dest: "/root/.kube/config"
     state: link
-  

--- a/roles/rke2_server/tasks/utilities.yml
+++ b/roles/rke2_server/tasks/utilities.yml
@@ -1,0 +1,82 @@
+# - name: Symlink crictl to /usr/local/bin
+#   ansible.builtin.file:
+#     src: "/var/lib/rancher/rke2/bin/crictl"
+#     dest: "/usr/local/bin/crictl"
+#     state: link
+
+# - name: Symlink crictl config to /etc/crictl.yaml
+#   ansible.builtin.file:
+#     src: "/var/lib/rancher/rke2/agent/etc/crictl.yaml"
+#     dest: "/etc/crictl.yaml"
+#     state: link
+
+# - name: Symlink ctr to /usr/local/bin
+#   ansible.builtin.file:
+#     src: "/var/lib/rancher/rke2/bin/ctr"
+#     dest: "/usr/local/bin/ctr"
+#     state: link
+  
+# - name: Symlink kubectl to /usr/local/bin
+#   ansible.builtin.file:
+#     src: "/var/lib/rancher/rke2/bin/kubectl"
+#     dest: "/usr/local/bin/kubectl"
+#     state: link
+  
+# - name: Create .kube directory in /root
+#   ansible.builtin.file:
+#     path: /root/.kube
+#     state: directory
+#     mode: '0750'
+
+# - name: Symlink kubectl config to /root/.kube/config
+#   ansible.builtin.file:
+#     src: "/etc/rancher/rke2/rke2.yaml"
+#     dest: "/root/.kube/config"
+#     state: link
+
+# - name: Check if Helm is installed
+#   stat:
+#     path: "/usr/local/bin/helm"
+#   register: helm_installed
+#   when: 
+#      - helm_tar_url is defined
+#      - helm_tar_url | length > 0
+
+# - name: Get Helm version
+#   command: "/usr/local/bin/helm version"
+#   changed_when: false
+#   register: helm_installed_version
+#   when: helm_installed.stat.exists
+
+- name: Install Helm Tar from URL
+  ansible.builtin.unarchive:
+    remote_src: yes #allow file to be pulled via https
+    src: "{{ helm_tar_url }}"
+    dest: "/usr/local/bin"
+    extra_opts:
+      - --strip=1
+      - --wildcards
+      - '*/helm'
+  when: 
+    # - not helm_installed.stat.exists
+    - helm_tar_url is defined
+    - helm_tar_url | length > 0
+
+- name: Install Helm Binary from file
+  ansible.builtin.copy:
+    src: "{{ helm_binary_path }}"
+    dest: "/usr/local/bin/helm"
+  when:
+    - helm_binary_path is defined
+    - helm_binary_path | length > 0
+
+- name: Set Helm permissions
+  ansible.builtin.file:
+    path: /usr/local/bin/helm
+    owner: root
+    group: root
+    mode: '0755'
+  when:
+    - (helm_tar_url is defined and helm_tar_url | length > 0) or
+      (helm_binary_path is defined and helm_binary_path | length > 0)
+  

--- a/roles/rke2_server/tasks/utilities.yml
+++ b/roles/rke2_server/tasks/utilities.yml
@@ -1,5 +1,7 @@
+---
+
 - name: Add /var/lib/rancher/rke2/bin to PATH
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "/root/.bashrc"
     line: 'PATH=$PATH:/var/lib/rancher/rke2/bin'
     insertafter: EOF


### PR DESCRIPTION
## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

Configures kubectl, crictl, and ctr for use on all server nodes.

## Which issue(s) this PR fixes:

Fixes #219 

## Release Notes

```release-note
Adds /var/lib/rancher/rke2/bin to $PATH via /root/.bashc and sets the KUBECONFIG and CRI_CONFIG_FILE
```

