### PR TITLE
Feat: Add tls-san to rke2_config

### DIFF
--- a/inventory/sample/hosts.yml
+++ b/inventory/sample/hosts.yml
@@ -53,6 +53,9 @@ rke2_cluster:
           # # See https://docs.rke2.io/helm/#automatically-deploying-manifests-and-helm-charts
           # # Add manifest files by specifying the directory path on the control host
           # manifest_config_file_path: "{{ playbook_dir }}/sample_files/manifest/"
+          # # See https://docs.rke2.io/reference/server_config#listener
+          # # Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert
+          # tls_san: "kubectl.example.com"
       hosts:
         # # Optional hostvars that can be pased in to individual nodes include
         # # node_ip, node_name, bind_address, advertise_address, node_taints=[],

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -184,6 +184,22 @@
     rke2_config: "{{ updated_rke2_config.rke2_config }}"
   when: (cloud_provider_name is defined) and (cloud_provider_name|length > 0)
 
+# --tls-san value to add custom Subject Alternative Names (SANs) for RKE2
+- name: Add tls-san to rke2_config
+  ansible.utils.update_fact:
+    updates:
+      - path: rke2_config["tls-san"]
+        value: "{{ tls_san }}"
+  when: (tls_san is defined) and (tls_san|length > 0)
+  register: updated_rke2_config
+  changed_when: false
+     
+- name: Update rke2_config to take value of updated_rke2_config  # noqa no-handler
+  ansible.builtin.set_fact:
+    rke2_config: "{{ updated_rke2_config.rke2_config }}"
+  when: (tls_san is defined) and (tls_san|length > 0)
+  changed_when: false
+
 - name: Remove tmp config file
   ansible.builtin.file:
     path: /tmp/ansible-config.txt


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

When trying to reach kube-api server using a kubeconfig with some DNS somednsexample.co, the following error is showing :
```
tls: failed to verify certificate: x509: certificate is valid for kubernetes, kubernetes.default, kubernetes.default.svc, kubernetes.default.svc.cluster.local, localhost, not for somednsexample.com
```
A solution would be to add the following in /etc/rancher/rke2/config.yaml:
```
tls-san:
  - somednsexample.com
```
https://docs.rke2.io/reference/server_config#listener

Right now, it is not supported in the Ansible role.

## Which issue(s) this PR fixes:

_(REQUIRED)_
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->
No issue.

## Testing

Tests cases:
- deploying new cluster,
- updating existing cluster.

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Feat: Add tls-san to rke2_config
```

