### PR TITLE
adding support for systemd env options

### DIFF
--- a/inventory/sample/group_vars/rke2_agents.yml
+++ b/inventory/sample/group_vars/rke2_agents.yml
@@ -8,3 +8,10 @@ rke2_config: {}
 # See https://docs.rke2.io/install/containerd_registry_configuration/
 # Add a registry configuration file by specifying the file path on the control host
 # registry_config_file_path: "{{ playbook_dir }}/sample_files/registries.yaml"
+
+# See https://docs.rke2.io/advanced#configuring-an-http-proxy
+# Add proxy information for the systemd environment
+# systemd_extra_env:
+# #- HTTP_PROXY=http://your-proxy.example.com:8888
+# #- HTTPS_PROXY=http://your-proxy.example.com:8888
+# #- NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/inventory/sample/group_vars/rke2_servers.yml
+++ b/inventory/sample/group_vars/rke2_servers.yml
@@ -51,3 +51,10 @@ rke2_config: {}
 # Add a pod security admission config file by specifying the file path on the control host
 # Requires config.yaml to include `- admission-control-config-file=/etc/rancher/rke2/pod-security-admission-config.yaml` in order for this to be honored
 # pod_security_admission_config_file_path: "{{ playbook_dir }}/sample_files/pod-security-admission-config.yaml"
+
+# See https://docs.rke2.io/advanced#configuring-an-http-proxy
+# Add proxy information for the systemd environment
+# systemd_extra_env:
+# #- HTTP_PROXY=http://your-proxy.example.com:8888
+# #- HTTPS_PROXY=http://your-proxy.example.com:8888
+# #- NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -24,3 +24,5 @@ rke2_versioned_yum_repo:
   enabled: yes
 
 rke2_config: {}
+
+systemd_extra_env: {}

--- a/roles/rke2_common/handlers/main.yml
+++ b/roles/rke2_common/handlers/main.yml
@@ -6,11 +6,13 @@
     name: systemd-sysctl
 
 - name: Restart rke2-server
+  throttle: 1
   ansible.builtin.service:
     state: restarted
     name: rke2-server
 
 - name: Restart rke2-agent
+  throttle: 1
   ansible.builtin.service:
     state: restarted
     name: rke2-agent

--- a/roles/rke2_common/tasks/add-systemd-env.yml
+++ b/roles/rke2_common/tasks/add-systemd-env.yml
@@ -1,0 +1,59 @@
+---
+- name: Add the systemd env file for rke2-{{ rke2_common_caller_role_name }}
+  when: (systemd_extra_env is defined) and (systemd_extra_env|length > 0)
+  ansible.builtin.blockinfile:
+    path: /etc/default/rke2-{{ rke2_common_caller_role_name }}
+    marker: "#{mark} This is an Ansible managed file, contents will be overwritten"
+    create: true
+    mode: '640'
+    owner: root
+    group: root
+    block: |
+      {% for item in systemd_extra_env %}
+      {{ item }}
+      {% endfor %}
+  register: systemd_added
+
+- name: Remove the systemd env file
+  when:
+    - (systemd_extra_env is not defined) or (systemd_extra_env|length == 0)
+  block:
+    - name: Check that the systemd env file exists
+      ansible.builtin.stat:
+        path: /etc/default/rke2-{{ rke2_common_caller_role_name }}
+      register: stat_result
+
+    - name: "Check that the systemd env file has ansible managed comments"
+      ansible.builtin.lineinfile:
+        name: "/etc/default/rke2-{{ rke2_common_caller_role_name }}"
+        line: '#BEGIN This is an Ansible managed file, contents will be overwritten'
+        state: present
+      check_mode: yes
+      register: ansible_managed_check
+      when: stat_result.stat.exists | bool is true
+
+    - name: Remove the systemd env file if exists and has ansible managed comments
+      ansible.builtin.file:
+        path: "/etc/default/rke2-{{ rke2_common_caller_role_name }}"
+        state: absent
+      when:
+        - ansible_managed_check.changed | bool is false
+      register: systemd_removed
+
+# Reload systemd if adding env file on initial build
+- name: Reload the systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when:
+    - systemd_added is changed
+    - installed is false
+
+# Reload and restart service if adding/removing env file post install
+- name: Reload the systemd daemon and notify restart of rke2-{{ rke2_common_caller_role_name }}
+  ansible.builtin.systemd:
+    daemon_reload: true
+  changed_when: true
+  notify: Restart rke2-{{ rke2_common_caller_role_name }}
+  when:
+    - (systemd_added is changed) or (systemd_removed is changed)
+    - installed is true

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -74,6 +74,9 @@
   ansible.builtin.include_tasks: add-registry-config.yml
   when: registry_config_file_path | length > 0
 
+- name: Include task file add-systemd-env.yml
+  ansible.builtin.include_tasks: add-systemd-env.yml
+
 - name: Run CIS-Hardening Tasks
   ansible.builtin.include_role:
     name: rke2_common


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

It adds the optional ability to add and configure an rke-{server,agent} systemd environment file to /etc/default

## Which issue(s) this PR fixes:

Fixes #169
Rework of #174 

## Release Notes

```release-note
NONE
```

