### PR TITLE
Add retries to rke2-server and rke2-agent RPM install tasks

### DIFF
--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -38,6 +38,10 @@
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists
     - inventory_hostname in groups['rke2_servers']
+  register: result
+  retries: 10
+  until: result is succeeded
+  delay: 30
 
 - name: YUM-Based | Install rke2-agent
   ansible.builtin.yum:
@@ -47,3 +51,7 @@
     - ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == 'Rocky'
     - not rke2_binary_tarball_check.stat.exists
     - inventory_hostname in groups.get('rke2_agents', [])
+  register: result
+  retries: 10
+  until: result is succeeded
+  delay: 30


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

We experience frequent issues when attempting to install the `rke2-server` and `rke2-agent` RPMs.
The failures happen most frequently with the `rke2-agent` RPM for whatever reason. The addition of
retries has allowed our RPM installations to not have any issues over the last 4+ weeks with this modification
locally.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes #250 

## Special notes for your reviewer:

We have been running with this modification with no issues for over a month now.

## Testing

Unfortunately, it was intermittent, so with a series of automated tests, this would show itself every
now and then in a cloud-based environment.

## Release Notes

N/A

