### PR TITLE
allowing changes to data-dir

### DIFF
--- a/roles/cluster_manifest/tasks/main.yml
+++ b/roles/cluster_manifest/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Add cluster manifest addons files
   ansible.builtin.copy:
     src: "{{ cluster_manifest_config_file_path }}"
-    dest: "/var/lib/rancher/rke2/server/manifests/"
+    dest: "{{ rke2_data_dir }}/server/manifests/"
     mode: '0640'
     owner: root
     group: root

--- a/roles/rke2_common/tasks/add-manifest-addons.yml
+++ b/roles/rke2_common/tasks/add-manifest-addons.yml
@@ -3,7 +3,7 @@
 - name: Add manifest addons files
   ansible.builtin.copy:
     src: "{{ manifest_config_file_path }}"
-    dest: "/var/lib/rancher/rke2/server/manifests/"
+    dest: "{{ rke2_data_dir }}/server/manifests/"
     mode: '0640'
     owner: root
     group: root

--- a/roles/rke2_common/tasks/images_tarball_install.yml
+++ b/roles/rke2_common/tasks/images_tarball_install.yml
@@ -17,14 +17,14 @@
 
 - name: Create images directory
   ansible.builtin.file:
-    path: /var/lib/rancher/rke2/agent/images
+    path: "{{ rke2_data_dir }}/agent/images"
     state: directory
     mode: '0644'
 
 - name: Download images tar files url
   ansible.builtin.get_url:
     url: "{{ item }}"
-    dest: "/var/lib/rancher/rke2/agent/images"
+    dest: "{{ rke2_data_dir }}/agent/images"
     mode: "0644"
   when:
     - rke2_images_urls != []
@@ -33,13 +33,13 @@
 - name: Add images tar.gz to needed directory if provided
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.gz"
-    dest: /var/lib/rancher/rke2/agent/images/
+    dest: "{{ rke2_data_dir }}/agent/images/"
     mode: '0644'
   when: got_images_gz.stat.exists
 
 - name: Add images tar.zst to needed directory if provided
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/tarball_install/rke2-images.linux-amd64.tar.zst"
-    dest: /var/lib/rancher/rke2/agent/images/
+    dest: "{{ rke2_data_dir }}/agent/images/"
     mode: '0644'
   when: got_images_zst.stat.exists

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -7,6 +7,20 @@
   ansible.builtin.package_facts:
     manager: auto
 
+- name: Set data-dir from rke2_config var
+  ansible.builtin.set_fact:
+    rke2_data_dir: "{{ rke2_config['data-dir'] }}"
+  when: rke2_config['data-dir'] is defined
+
+- name: Set data-dir var
+  ansible.builtin.set_fact:
+    rke2_data_dir: '/var/lib/rancher/rke2'
+  when: rke2_data_dir is not defined
+
+- name: debug
+  debug:
+    msg: "data-dir is {{ rke2_data_dir }}"
+
 - name: Has rke2 been installed already
   ansible.builtin.include_tasks: previous_install.yml
 

--- a/roles/rke2_server/tasks/first_server.yml
+++ b/roles/rke2_server/tasks/first_server.yml
@@ -38,7 +38,7 @@
 
 - name: Wait for node to show Ready status
   ansible.builtin.command: >-
-    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    {{ rke2_data_dir }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
     --server https://127.0.0.1:6443 get no {{ kubelet_hostname_override_parameter[0] }}
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: status_result
@@ -51,11 +51,11 @@
   block:
     - name: Wait for node-token
       ansible.builtin.wait_for:
-        path: /var/lib/rancher/rke2/server/node-token
+        path: "{{ rke2_data_dir }}/server/node-token"
 
     - name: Read node-token from master
       ansible.builtin.slurp:
-        src: /var/lib/rancher/rke2/server/node-token
+        src: "{{ rke2_data_dir }}/server/node-token"
       register: node_token
 
     - name: Store Master node-token

--- a/roles/rke2_server/tasks/other_servers.yml
+++ b/roles/rke2_server/tasks/other_servers.yml
@@ -61,7 +61,7 @@
 
 - name: Wait for node to show Ready status
   ansible.builtin.command: >-
-    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    {{ rke2_data_dir }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
     --server https://127.0.0.1:6443 get no {{ kubelet_hostname_override_parameter[0] }}
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: status_result

--- a/roles/rke2_server/tasks/utilities.yml
+++ b/roles/rke2_server/tasks/utilities.yml
@@ -1,14 +1,14 @@
 ---
 
-- name: Add /var/lib/rancher/rke2/bin to PATH
+- name: Add rke2/bin to PATH
   ansible.builtin.lineinfile:
     dest: "/root/.bashrc"
-    line: 'PATH=$PATH:/var/lib/rancher/rke2/bin'
+    line: "PATH=$PATH:{{ rke2_data_dir }}/bin"
     insertafter: EOF
 
 - name: Symlink crictl config to /etc/crictl.yaml
   ansible.builtin.file:
-    src: "/var/lib/rancher/rke2/agent/etc/crictl.yaml"
+    src: "{{ rke2_data_dir }}/agent/etc/crictl.yaml"
     dest: "/etc/crictl.yaml"
     state: link
 
@@ -20,6 +20,6 @@
 
 - name: Symlink kubectl config to /root/.kube/config
   ansible.builtin.file:
-    src: "/var/lib/rancher/rke2/server/cred/admin.kubeconfig"
+    src: "{{ rke2_data_dir }}/server/cred/admin.kubeconfig"
     dest: "/root/.kube/config"
     state: link


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

RKE2 allows for a `data-dir` variable to be passed in via rke2/config.yaml that will allow a user to specify a different path other then /var/lib/rancher/rke2. Since that path is hard coded throughout the module, this creates a variable with that value and replaces all hard coded references.

Things to note, SELINUX might not work correctly since the new path isn't configured via rke2-selinux and rke2-uninstall.sh won't clean up this directory since it doesn't know about it. 

## Which issue(s) this PR fixes:

Fixes #254 

