### PR TITLE
Run Handlers When Services Should Exist

### DIFF
--- a/roles/rke2/handlers/main.yml
+++ b/roles/rke2/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Restart systemd-sysctl
   ansible.builtin.service:
     state: restarted
@@ -22,6 +21,7 @@
   throttle: 1
   when:
     - not rke2_reboot
+    - ("rke2_servers" in group_names)
 
 - name: Restart rke2-agent
   ansible.builtin.service:
@@ -31,6 +31,7 @@
   throttle: 1
   when:
     - not rke2_reboot
+    - ("rke2_agents" in group_names)
 
 - name: Reload NetworkManager
   ansible.builtin.systemd:

--- a/roles/rke2/tasks/tarball_install.yml
+++ b/roles/rke2/tasks/tarball_install.yml
@@ -16,7 +16,7 @@
   when:
     - rke2_install_local_tarball_path == ""
     - rke2_install_tarball_url == ""
-    - not rke2_installed or rke2_installed_version != rke2_full_version
+    - not rke2_installed or rke2_installed_version | default("") != rke2_full_version
 
 - name: Send provided tarball from local control machine if available
   ansible.builtin.copy:


### PR DESCRIPTION
* The `rke2-*` services might not exist so make sure to check if they should be there prior to trying to reset them.
* `rke2_installed_version` is not defined prior to use. default it to an empty string.

## What type of PR is this?

_(REQUIRED)_

- [X] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

The role fails to restart services during a tarball install because it tries to restart services for both `rke2-server` and `rke2-agent` regardless of what was installed.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #275 

## Testing

Tested on SLES15 SP6 VMs created by Terraform against a cloud-init based image on vSphere in our CI.

## Release Notes

_(REQUIRED)_

```release-note
* Ensures only installed services are attempted to be reinstalled if notified during the tarball install
```

