### PR TITLE
287 tarball install logic is flawed

### DIFF
--- a/roles/rke2/tasks/cis_hardening.yml
+++ b/roles/rke2/tasks/cis_hardening.yml
@@ -37,7 +37,7 @@
 
     - name: Copy systemctl file for kernel hardening for non-yum installs
       ansible.builtin.copy:
-        src: /usr/local/share/rke2/rke2-cis-sysctl.conf
+        src: "{{ rke2_tarball_install_dir }}/share/rke2/rke2-cis-sysctl.conf"
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: true
         mode: 0600

--- a/roles/rke2/tasks/tarball_install.yml
+++ b/roles/rke2/tasks/tarball_install.yml
@@ -111,20 +111,19 @@
         src: "{{ temp_dir.path }}/rke2.linux-{{ arch }}.tar.gz"
         dest: "{{ rke2_tarball_install_dir }}"
         remote_src: true
+      notify: Restart {{ service_name }}
 
     - name: TARBALL | Updating rke2-server.service
       ansible.builtin.replace:
         path: "{{ rke2_tarball_install_dir }}/lib/systemd/system/rke2-server.service"
         regexp: '/usr/local'
         replace: '{{ rke2_tarball_install_dir }}'
-      notify: Restart rke2-server
 
     - name: TARBALL | Updating rke2-agent.service
       ansible.builtin.replace:
         path: "{{ rke2_tarball_install_dir }}/lib/systemd/system/rke2-agent.service"
         regexp: '/usr/local'
         replace: '{{ rke2_tarball_install_dir }}'
-      notify: Restart rke2-agent
 
     - name: TARBALL | Updating rke2-uninstall.sh
       ansible.builtin.replace:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

When doing a Tarball installation, if the path was not the default, both rke2-server and rke2-agent would be triggered to restart for each node.

## Which issue(s) this PR fixes:

Fixes #287 

## Release Notes

```release-note
Logic fix for Tarball install where the install path is not default
```

