### PR TITLE
Make the value of rke2_kubernetes_api_server_host more robust

### DIFF
--- a/roles/rke2/tasks/save_generated_token.yml
+++ b/roles/rke2/tasks/save_generated_token.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait for node-token
   ansible.builtin.wait_for:
     path: /var/lib/rancher/rke2/server/node-token
@@ -27,7 +26,7 @@
 
 - name: Set temp fact for api host
   ansible.builtin.set_fact:
-    rke2_kubernetes_api_server_host: "{{ token_source_node }}"
+    rke2_kubernetes_api_server_host: "{{ hostvars[token_source_node]['ansible_default_ipv4']['address'] }}"
   when:
     - rke2_kubernetes_api_server_host == ""
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?


- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
This PR fixes a bug which makes the rke role unusable for those using certain dynamic inventory sources.

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

The issue is with the value of the `rke2_kubernetes_api_server_host` variable. If, like us, you are using a dynamic inventory which does not set the inventory host name to a valid IP address but instead a UUID, the role will fail when waiting for the API server to be ready.

## Testing

<!--
  Describe how you tested this change.
-->
This was tested numerous times by deploying new VMs and applying the role, with and without the change. It has not been tested with other inventory sources.


## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
NONE
```

