### PR TITLE
adding ability to skip installs on subsequent runs; fixing logic to d…

### DIFF
--- a/roles/rke2/defaults/main.yml
+++ b/roles/rke2/defaults/main.yml
@@ -93,6 +93,9 @@ rke2_manifest_config_post_run_directory: ""
 ## Path, local to Ansible control host, where systemd environment file config can be found (Proxy Config).
 rke2_systemd_env_config_file_path: ""
 
+## Set to 'false' if Ansible should not attempt to upgrade an installed version of RKE2. This is useful if using the System Upgrade Controller to manage the installed version of RKE2.
+rke2_upgrade: true
+
 # Should not be changed:
 rke2_metrics_running: false
 rke2_node_ready: "false"
@@ -103,3 +106,4 @@ rke2_reboot: false
 rke2_version_majmin: ""
 rke2_version_rpm: ""
 rke2_package_state: "installed"
+

--- a/roles/rke2/defaults/main.yml
+++ b/roles/rke2/defaults/main.yml
@@ -106,4 +106,3 @@ rke2_reboot: false
 rke2_version_majmin: ""
 rke2_version_rpm: ""
 rke2_package_state: "installed"
-

--- a/roles/rke2/tasks/check_node_ready.yml
+++ b/roles/rke2/tasks/check_node_ready.yml
@@ -61,7 +61,7 @@
 
 - name: Set fact
   ansible.builtin.set_fact:
-    rke2_node_ready: "true"
+    rke2_node_ready: true
   when:
     - status_result.rc is not undefined
     - status_result.rc | string == "0"

--- a/roles/rke2/tasks/main.yml
+++ b/roles/rke2/tasks/main.yml
@@ -42,13 +42,13 @@
 - name: Create a list of ready servers
   ansible.builtin.set_fact:
     ready_servers: >-
-      {{ 
-        groups.rke2_servers 
-        | map('extract', hostvars) 
-        | selectattr('rke2_node_ready', 'defined') 
-        | selectattr('rke2_node_ready', 'equalto', true) 
-        | map(attribute='inventory_hostname') 
-        | list 
+      {{
+        groups.rke2_servers
+        | map('extract', hostvars)
+        | selectattr('rke2_node_ready', 'defined')
+        | selectattr('rke2_node_ready', 'equalto', true)
+        | map(attribute='inventory_hostname')
+        | list
       }}
   delegate_to: localhost
   run_once: true
@@ -56,6 +56,8 @@
     - (groups.rke2_servers | map('extract', hostvars) | selectattr('rke2_node_ready', 'defined') | selectattr('rke2_node_ready', 'equalto', true) | list | length) > 0
 
 - name: Install RKE2
+  when:
+    - (rke2_installed is false) or (rke2_installed is true and rke2_upgrade is true)
   block:
     - name: Tarball Install
       ansible.builtin.include_tasks: tarball_install.yml
@@ -65,8 +67,6 @@
       ansible.builtin.include_tasks: rpm_install.yml
       when:
         - install_method == "rpm"
-  when:
-    - (rke2_installed is false) or (rke2_installed is true and rke2_upgrade is true)
 
 - name: Set rke2 configuration files
   ansible.builtin.include_tasks: configure_rke2.yml

--- a/roles/rke2/tasks/main.yml
+++ b/roles/rke2/tasks/main.yml
@@ -41,22 +41,32 @@
 
 - name: Create a list of ready servers
   ansible.builtin.set_fact:
-    ready_servers: "{{ groups.rke2_servers | map('extract', hostvars) | selectattr('rke2_node_ready', 'equalto', true) | map(attribute='inventory_hostname') | list }}"
+    ready_servers: >-
+      {{ 
+        groups.rke2_servers 
+        | map('extract', hostvars) 
+        | selectattr('rke2_node_ready', 'defined') 
+        | selectattr('rke2_node_ready', 'equalto', true) 
+        | map(attribute='inventory_hostname') 
+        | list 
+      }}
   delegate_to: localhost
   run_once: true
   when:
     - (groups.rke2_servers | map('extract', hostvars) | selectattr('rke2_node_ready', 'defined') | selectattr('rke2_node_ready', 'equalto', true) | list | length) > 0
-  tags: ["configure"]
 
-- name: Tarball Install
-  ansible.builtin.include_tasks: tarball_install.yml
+- name: Install RKE2
+  block:
+    - name: Tarball Install
+      ansible.builtin.include_tasks: tarball_install.yml
+      when:
+        - install_method == "tarball"
+    - name: RPM Install
+      ansible.builtin.include_tasks: rpm_install.yml
+      when:
+        - install_method == "rpm"
   when:
-    - install_method == "tarball"
-
-- name: RPM Install
-  ansible.builtin.include_tasks: rpm_install.yml
-  when:
-    - install_method == "rpm"
+    - (rke2_installed is false) or (rke2_installed is true and rke2_upgrade is true)
 
 - name: Set rke2 configuration files
   ansible.builtin.include_tasks: configure_rke2.yml


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [X] bug
- [ ] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

Allows for rke2-ansible to NOT install RKE2 if it's already installed. On RPM installs, RKE2 automatically restarts when the RPM gets installed. This causes all nodes to restart at the same time potentially causing issue.

## Which issue(s) this PR fixes:

_(REQUIRED)_
Fixes !15

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```

