### PR TITLE
Fix open issues and improve CI

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,0 +1,32 @@
+---
+name: Publish Galaxy
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install ansible-core
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ansible-core
+
+      - name: Build collection
+        run: ansible-galaxy collection build --force
+
+      - name: Publish collection
+        env:
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: ansible-galaxy collection publish *.tar.gz --api-key "$ANSIBLE_GALAXY_API_KEY"

--- a/.github/workflows/reusable_integration_testing.yml
+++ b/.github/workflows/reusable_integration_testing.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update -y
-          sudo apt install terraform -y
+          sudo apt install terraform jq -y
           sudo snap install yq
           python -m pip install --upgrade pip
           pip3 install ansible pytest-testinfra
@@ -114,13 +114,30 @@ jobs:
           cat ./${{ inputs.os }}/hosts.yml
           cat ansible.cfg
 
-      - name: Run playbook
+      - name: Resolve RKE2 upgrade versions
+        id: rke2_versions
         run: |
-          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} -vv --private-key .key site.yml
+          releases="$(curl -sL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/rancher/rke2/releases?per_page=20)"
+          latest="$(echo "$releases" | jq -r '[.[] | select(.prerelease == false) | .tag_name][0]')"
+          previous="$(echo "$releases" | jq -r '[.[] | select(.prerelease == false) | .tag_name][1]')"
+          if [ -z "$latest" ] || [ -z "$previous" ] || [ "$latest" = "null" ] || [ "$previous" = "null" ]; then
+            echo "Failed to resolve RKE2 versions for upgrade testing."
+            exit 1
+          fi
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+
+      - name: Run playbook (previous version)
+        run: |
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} -vv --private-key .key -e "rke2_install_version=${{ steps.rke2_versions.outputs.previous }}" site.yml
+
+      - name: Run playbook (upgrade to latest)
+        run: |
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} -vv --private-key .key -e "rke2_install_version=${{ steps.rke2_versions.outputs.latest }}" site.yml
 
       - name: Run playbook again for idempotency
         run: |
-          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} -vv --private-key .key site.yml
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} -vv --private-key .key -e "rke2_install_version=${{ steps.rke2_versions.outputs.latest }}" site.yml
 
       - name: Run Ansible Tests
         run: |
@@ -143,7 +160,7 @@ jobs:
           
       - name: Run playbook again with added host
         run: |
-          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} --verbose --private-key .key site.yml
+          ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ./${{ inputs.os }}/hosts.yml -u ${{ inputs.ssh_user }} --verbose --private-key .key -e "rke2_install_version=${{ steps.rke2_versions.outputs.latest }}" site.yml
 
       - name: Run Ansible Tests with added host
         run: |

--- a/.github/workflows/sles.yml
+++ b/.github/workflows/sles.yml
@@ -1,0 +1,15 @@
+---
+name: SLES
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  "_15_":
+    uses: ./.github/workflows/reusable_integration_testing.yml
+    with:
+      os: sles15
+      ssh_user: ec2-user
+    secrets: inherit

--- a/.yamllint
+++ b/.yamllint
@@ -2,11 +2,20 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
   line-length:
     max: 200
     level: warning
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 
 ignore: |
+  .ansible/
   .github/
   inventory/sample/group_vars/rke2_servers.yml
   inventory/sample/group_vars/rke2_agents.yml

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,7 @@
 # Table of Contents  
 - [Table of Contents](#table-of-contents)
 - [Dependencies](#dependencies)
+- [Molecule Testing](#molecule-testing)
 
 # Dependencies  
 This playbook requires ansible.utils to run properly. Please see https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-a-collection-from-galaxy for more information about how to install this.
@@ -8,3 +9,30 @@ This playbook requires ansible.utils to run properly. Please see https://docs.an
 ```
 ansible-galaxy collection install -r requirements.yml
 ```
+
+# Molecule Testing
+The Molecule scenarios in `roles/rke2/molecule` use the EC2 driver to test on real instances.
+You can run them locally from a laptop as long as you have AWS credentials and a VPC subnet ID.
+
+Prerequisites:
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (or `AWS_PROFILE`)
+- `VPC_SUBNET_ID`
+
+Install dependencies:
+```
+python -m pip install -r roles/rke2/molecule/requirements.txt
+ansible-galaxy collection install -r requirements.yml
+```
+
+Run a scenario:
+```
+cd roles/rke2
+molecule test -s rocky-89
+```
+
+Available scenarios:
+- `rocky-89`
+- `rocky-94`
+- `ubuntu-2204`
+- `ubuntu-2404`
+- `sles-15`

--- a/roles/rke2/defaults/main.yml
+++ b/roles/rke2/defaults/main.yml
@@ -33,7 +33,7 @@ rke2_kubelet_node_name:
   - "nodeNameNotFound"
 rke2_config: {}
 rke2_metrics_running: false
-rke2_node_ready: "false"
+rke2_node_ready: false
 rke2_api_server_running: false
 rke2_installed: false
 rke2_version_changed: false
@@ -42,3 +42,7 @@ rke2_version_majmin: ""
 rke2_version_rpm: ""
 rke2_package_state: "installed"
 rke2_systemd_env_config_file_path: ""
+rke2_check_node_ready_timeout: 600
+rke2_check_node_ready_retries: 60
+rke2_check_node_ready_delay: 10
+rke2_wait_for_api_server_timeout: 600

--- a/roles/rke2/tasks/NOT_USED_cluster_state.yml
+++ b/roles/rke2/tasks/NOT_USED_cluster_state.yml
@@ -8,14 +8,14 @@
     - name: Check for node-token (existing cluster)
       ansible.builtin.stat:
         path: /var/lib/rancher/rke2/server/node-token
-      register: node_token_tmp
+      register: rke2_node_token_tmp
 
     - name: Read node-token (existing cluster)
       ansible.builtin.slurp:
         src: /var/lib/rancher/rke2/server/node-token
       register: rke2_config_token_tmp
       when:
-        - node_token_tmp.stat.exists
+        - rke2_node_token_tmp.stat.exists
 
     - name: Set node-token fact (existing cluster)
       ansible.builtin.set_fact:
@@ -39,21 +39,21 @@
 
     - name: Read host with token (existing cluster)
       ansible.builtin.set_fact:
-        existing_join_host: "{{ ansible_hostname }}"
+        rke2_existing_join_host: "{{ ansible_hostname }}"
       when:
-        - node_token_tmp.stat.exists
+        - rke2_node_token_tmp.stat.exists
 
     - name: Set join server fact on all hosts (existing cluster)
       ansible.builtin.set_fact:
-        rke2_kubernetes_api_server_host: "{{ hostvars[item]['existing_join_host'] }}"
+        rke2_kubernetes_api_server_host: "{{ hostvars[item]['rke2_existing_join_host'] }}"
       delegate_to: localhost
       run_once: true
       loop: "{{ groups['all'] }}"
       when:
-        - "hostvars[item]['existing_join_host'] is defined"
+        - "hostvars[item]['rke2_existing_join_host'] is defined"
         - hostvars[item]['rke2_kubernetes_api_server_host'] == ""
       vars:
-        rke2_kubernetes_api_server_host: "{{ existing_join_host | default('') }}"
+        rke2_kubernetes_api_server_host: "{{ rke2_existing_join_host | default('') }}"
 
 - name: No existing cluster found and api server not set
   ansible.builtin.set_fact:

--- a/roles/rke2/tasks/add_ansible_managed_config.yml
+++ b/roles/rke2/tasks/add_ansible_managed_config.yml
@@ -8,7 +8,7 @@
     group: root
   when:
     - file_path | default("") | length != 0
-  notify: "Restart {{ service_name }}"
+  notify: "Restart {{ rke2_service_name }}"
 
 - name: "Remove {{ file_description }} file"  # noqa name[template]
   when:
@@ -17,7 +17,7 @@
     - name: "Check that the {{ file_description }} file exists"  # noqa name[template]
       ansible.builtin.stat:
         path: "{{ file_destination }}"
-      register: stat_result
+      register: rke2_stat_result
 
     - name: "Check that the {{ file_description }} config file has ansible managed comments"  # noqa name[template]
       ansible.builtin.lineinfile:
@@ -25,13 +25,13 @@
         line: '## This is an Ansible managed file, contents will be overwritten ##'
         state: present
       check_mode: true
-      register: ansible_managed_check
-      when: stat_result.stat.exists | bool is true
+      register: rke2_ansible_managed_check
+      when: rke2_stat_result.stat.exists | bool is true
 
     - name: "Remove the {{ file_description }} file if exists and has ansible managed comments"  # noqa name[template]
       ansible.builtin.file:
         path: "{{ file_destination }}"
         state: absent
       when:
-        - ansible_managed_check.changed | bool is false  # noqa no-handler
-      notify: "Restart {{ service_name }}"
+        - rke2_ansible_managed_check.changed | bool is false  # noqa no-handler
+      notify: "Restart {{ rke2_service_name }}"

--- a/roles/rke2/tasks/add_manifest_addons.yml
+++ b/roles/rke2/tasks/add_manifest_addons.yml
@@ -3,13 +3,13 @@
 - name: Look up manifest files on localhost
   ansible.builtin.find:
     paths: "{{ source_directory }}"
-  register: local_files_find_return
+  register: rke2_local_files_find_return
   delegate_to: localhost
   become: false
 
 - name: Create array of managed files
   ansible.builtin.set_fact:
-    managed_files: "{{ local_files_find_return.files | map(attribute='path') | map('basename') }}"
+    rke2_managed_files: "{{ rke2_local_files_find_return.files | map(attribute='path') | map('basename') }}"
 
 - name: Add manifest addons files from localhost
   ansible.builtin.copy:
@@ -22,15 +22,15 @@
 - name: Look up manifest files on remote
   ansible.builtin.find:
     paths: "{{ destination_directory }}"
-  register: remote_files_find_return
+  register: rke2_remote_files_find_return
 
 - name: Create array of remote files
   ansible.builtin.set_fact:
-    current_files: "{{ remote_files_find_return.files | map(attribute='path') | map('basename') }}"
+    rke2_current_files: "{{ rke2_remote_files_find_return.files | map(attribute='path') | map('basename') }}"
 
 - name: Remove remote files not in managed files list
   ansible.builtin.file:
     path: "{{ destination_directory }}/{{ item }}"
     state: absent
-  with_items: "{{ current_files }}"
-  when: item not in managed_files
+  with_items: "{{ rke2_current_files }}"
+  when: item not in rke2_managed_files

--- a/roles/rke2/tasks/calculate_rke2_version.yml
+++ b/roles/rke2/tasks/calculate_rke2_version.yml
@@ -51,7 +51,7 @@
 
 - name: "Set install version for RPM"
   when:
-    - install_method == "rpm"
+    - rke2_install_method == "rpm"
     - rke2_full_version | length > 0
   block:
 

--- a/roles/rke2/tasks/check_node_ready.yml
+++ b/roles/rke2/tasks/check_node_ready.yml
@@ -7,19 +7,15 @@
     state: present
     timeout: "{{ check_node_ready_timeout }}"
   changed_when: false
-  register: api_serve_status
+  register: rke2_api_server_status
   ignore_errors: "{{ check_node_ready_ignore_errors }}"
 
 - name: Set fact
   ansible.builtin.set_fact:
     rke2_api_server_running: true
   when:
-    - api_serve_status.state is not undefined
-    - api_serve_status.state == "present"
-
-- name: Set fact
-  ansible.builtin.set_fact:
-    rke2_api_server_running: "{{ rke2_api_server_running }}"
+    - rke2_api_server_status.state is not undefined
+    - rke2_api_server_status.state == "present"
 
 - name: Get node_metrics
   ansible.builtin.uri:
@@ -28,7 +24,7 @@
     ca_path: /var/lib/rancher/rke2/server/tls/server-ca.crt
     client_cert: /var/lib/rancher/rke2/server/tls/client-admin.crt
     client_key: /var/lib/rancher/rke2/server/tls/client-admin.key
-  register: node_metrics
+  register: rke2_node_metrics
   retries: "{{ check_node_ready_retries }}"
   delay: "{{ check_node_ready_delay }}"
   ignore_errors: "{{ check_node_ready_ignore_errors }}"
@@ -37,40 +33,46 @@
   ansible.builtin.set_fact:
     rke2_metrics_running: true
   when:
-    - 200 | string in node_metrics.status | string
-
-- name: Set fact for rke2_metrics_running
-  ansible.builtin.set_fact:
-    rke2_metrics_running: "{{ rke2_metrics_running }}"
+    - (rke2_node_metrics.status | default('')) | string == "200"
 
 - name: Extract the kubelet_node_name from node metrics
   ansible.builtin.set_fact:
-    kubelet_node_name: "{{ node_metrics.content | regex_search('kubelet_node_name{node=\"(.*)\"}', '\\1') }}"
+    rke2_kubelet_node_name: "{{ rke2_node_metrics.content | regex_search('kubelet_node_name{node=\"(.*)\"}', '\\1') | default('', true) }}"
   when:
-    - 200 | string in node_metrics.status | string
+    - (rke2_node_metrics.status | default('')) | string == "200"
+
+- name: Fail if kubelet node name could not be determined
+  ansible.builtin.fail:
+    msg: "Unable to determine kubelet node name from metrics."
+  when:
+    - not check_node_ready_ignore_errors
+    - rke2_kubelet_node_name is not defined or rke2_kubelet_node_name | length == 0
 
 - name: Wait for node to show Ready status
   ansible.builtin.command: >-
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
-    --server https://127.0.0.1:6443 get no {{ kubelet_node_name[0] }}
+    --server https://127.0.0.1:6443 get node "{{ rke2_kubelet_node_name }}"
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-  register: status_result
-  until: status_result.stdout.find("True") != -1
+  register: rke2_status_result
+  until: rke2_status_result.stdout.find("True") != -1
   retries: "{{ check_node_ready_retries }}"
   delay: "{{ check_node_ready_delay }}"
   changed_when: false
   ignore_errors: "{{ check_node_ready_ignore_errors }}"
-
-- name: Set fact
-  ansible.builtin.set_fact:
-    rke2_node_ready: "true"
+  failed_when:
+    - not check_node_ready_ignore_errors
+    - (rke2_status_result.stdout | default('')) | string != "True"
   when:
-    - status_result.rc is not undefined
-    - status_result.rc | string == "0"
+    - rke2_kubelet_node_name is defined
+    - rke2_kubelet_node_name | length > 0
 
 - name: Set fact
   ansible.builtin.set_fact:
-    rke2_node_ready: "{{ rke2_node_ready }}"
+    rke2_node_ready: true
+  when:
+    - rke2_status_result is defined
+    - rke2_status_result.stdout is defined
+    - (rke2_status_result.stdout | string) == "True"
 
 - name: Node status
   ansible.builtin.debug:

--- a/roles/rke2/tasks/cis_hardening.yml
+++ b/roles/rke2/tasks/cis_hardening.yml
@@ -25,13 +25,13 @@
         src: /usr/share/rke2/rke2-cis-sysctl.conf
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: true
-        mode: 0600
-      register: sysctl_operation_yum
+        mode: '0600'
+      register: rke2_sysctl_operation_yum
       when:
-        - install_method == "rpm"
+        - rke2_install_method == "rpm"
       notify:
         - Restart systemd-sysctl
-        - "Restart {{ service_name }}"
+        - "Restart {{ rke2_service_name }}"
         - Reboot the machine
 
     - name: Copy systemctl file for kernel hardening for non-yum installs
@@ -39,13 +39,13 @@
         src: /usr/local/share/rke2/rke2-cis-sysctl.conf
         dest: /etc/sysctl.d/60-rke2-cis.conf
         remote_src: true
-        mode: 0600
-      register: sysctl_operation_tarball
+        mode: '0600'
+      register: rke2_sysctl_operation_tarball
       when:
-        - install_method == "tarball"
+        - rke2_install_method == "tarball"
       notify:
         - Restart systemd-sysctl
-        - "Restart {{ service_name }}"
+        - "Restart {{ rke2_service_name }}"
         - Reboot the machine
 
     # Per CIS hardening guide, if Kubernetes is already running, making changes to sysctl can result in unexpected
@@ -55,6 +55,6 @@
       ansible.builtin.set_fact:
         rke2_reboot: true
       when:
-        - (sysctl_operation_yum.changed or sysctl_operation_tarball.changed)
+        - (rke2_sysctl_operation_yum.changed or rke2_sysctl_operation_tarball.changed)
         - rke2_running is defined
         - rke2_running

--- a/roles/rke2/tasks/config.yml
+++ b/roles/rke2/tasks/config.yml
@@ -3,12 +3,12 @@
 # combine host and group vars to form primary rke2_config
 - name: Combine host and group config vars
   ansible.builtin.set_fact:
-    temp_group_rke2_config: "{{ cluster_rke2_config | default({}) | ansible.builtin.combine((group_rke2_config | default({})), list_merge='prepend_rp') }}"
+    rke2_temp_group_rke2_config: "{{ cluster_rke2_config | default({}) | ansible.builtin.combine((group_rke2_config | default({})), list_merge='prepend_rp') }}"
 
 # combine host and group vars to form primary rke2_config
 - name: Combine host and group config vars
   ansible.builtin.set_fact:
-    rke2_config: "{{ temp_group_rke2_config | default({}) | ansible.builtin.combine((host_rke2_config | default({})), list_merge='prepend_rp') }}"
+    rke2_config: "{{ rke2_temp_group_rke2_config | default({}) | ansible.builtin.combine((host_rke2_config | default({})), list_merge='prepend_rp') }}"
 
 # write final config
 - name: Create config.yaml
@@ -17,4 +17,4 @@
     block: "{{ rke2_config | to_nice_yaml(indent=0) }}"
     create: true
     mode: "0640"
-  notify: Restart {{ service_name }}
+  notify: Restart {{ rke2_service_name }}

--- a/roles/rke2/tasks/configure_rke2.yml
+++ b/roles/rke2/tasks/configure_rke2.yml
@@ -13,7 +13,7 @@
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
     file_contents: "{{ lookup('file', rke2_systemd_env_config_file_path) }}"
-    file_destination: "/etc/default/{{ service_name }}"
+    file_destination: "/etc/default/{{ rke2_service_name }}"
     file_description: "systemd env options"
     file_path: "{{ rke2_systemd_env_config_file_path }}"
 

--- a/roles/rke2/tasks/first_server.yml
+++ b/roles/rke2/tasks/first_server.yml
@@ -10,7 +10,7 @@
   ansible.builtin.service:
     state: started
     enabled: true
-    name: "{{ service_name }}"
+    name: "{{ rke2_service_name }}"
 
 - name: Check_node_ready
   any_errors_fatal: true
@@ -18,7 +18,7 @@
     - name: Start check_node_ready.yml
       ansible.builtin.include_tasks: check_node_ready.yml
       vars:
-        check_node_ready_timeout: 300
-        check_node_ready_retries: 30
-        check_node_ready_delay: 10
+        check_node_ready_timeout: "{{ rke2_check_node_ready_timeout }}"
+        check_node_ready_retries: "{{ rke2_check_node_ready_retries }}"
+        check_node_ready_delay: "{{ rke2_check_node_ready_delay }}"
         check_node_ready_ignore_errors: false

--- a/roles/rke2/tasks/images_bundle.yml
+++ b/roles/rke2/tasks/images_bundle.yml
@@ -14,7 +14,7 @@
   when:
     - rke2_images_urls != []
   with_items: "{{ rke2_images_urls }}"
-  notify: "Restart {{ service_name }}"
+  notify: "Restart {{ rke2_service_name }}"
 
 - name: Copy local tarball images
   ansible.builtin.copy:
@@ -25,4 +25,4 @@
     - "{{ rke2_images_local_tarball_path }}"
   when:
     - rke2_images_local_tarball_path != []
-  notify: "Restart {{ service_name }}"
+  notify: "Restart {{ rke2_service_name }}"

--- a/roles/rke2/tasks/main.yml
+++ b/roles/rke2/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Set for install method of tarball
   ansible.builtin.set_fact:
-    install_method: tarball
+    rke2_install_method: tarball
   when: |-
       ((ansible_facts['os_family'] != 'RedHat' and ansible_facts['os_family'] != 'Rocky') or
       rke2_install_tarball_url != "" or
@@ -18,7 +18,7 @@
 
 - name: Set for install method of rpm
   ansible.builtin.set_fact:
-    install_method: rpm
+    rke2_install_method: rpm
   when:
     - ansible_os_family == 'RedHat' or ansible_os_family == 'Rocky'
     - rke2_install_local_tarball_path == ""
@@ -27,13 +27,13 @@
 
 - name: Set as server
   ansible.builtin.set_fact:
-    service_name: rke2-server
+    rke2_service_name: rke2-server
   when:
     - inventory_hostname in groups['rke2_servers']
 
 - name: Set as agent
   ansible.builtin.set_fact:
-    service_name: rke2-agent
+    rke2_service_name: rke2-agent
   when:
     - inventory_hostname in groups.get('rke2_agents', [])
 
@@ -64,22 +64,29 @@
     check_node_ready_ignore_errors: true
   when:
     - inventory_hostname in groups['rke2_servers']
+    - rke2_running | default(false)
 
 - name: Create a list of ready servers
   ansible.builtin.set_fact:
-    ready_servers: "{{ groups.rke2_servers | map('extract', hostvars) | selectattr('rke2_node_ready', 'equalto', true) | map(attribute='inventory_hostname') | list }}"
+    rke2_ready_servers: >-
+      {{ groups.rke2_servers
+         | map('extract', hostvars)
+         | selectattr('rke2_node_ready', 'defined')
+         | selectattr('rke2_node_ready', 'equalto', true)
+         | map(attribute='inventory_hostname')
+         | list }}
   delegate_to: localhost
   run_once: true
 
 - name: Tarball Install
   ansible.builtin.include_tasks: tarball_install.yml
   when:
-    - install_method == "tarball"
+    - rke2_install_method == "tarball"
 
 - name: RPM Install
   ansible.builtin.include_tasks: rpm_install.yml
   when:
-    - install_method == "rpm"
+    - rke2_install_method == "rpm"
 
 - name: Set rke2 configuration files
   ansible.builtin.include_tasks: configure_rke2.yml
@@ -94,27 +101,27 @@
     - rke2_manifest_config_directory | length > 0
     - inventory_hostname in groups['rke2_servers'][0]
 
-# is the ready_servers array is empty, we assume it's a new cluster and use the first server in groups['rke2_servers']
+# if rke2_ready_servers is empty, assume a new cluster and use the first server in groups['rke2_servers']
 - name: Start the first rke2 node
   ansible.builtin.include_tasks: first_server.yml
   when:
     - inventory_hostname in groups['rke2_servers'][0]
-    - ready_servers | length == 0
+    - rke2_ready_servers | length == 0
 
 - name: Save_generated_token.yml
   ansible.builtin.include_tasks: save_generated_token.yml
   vars:
     token_source_node: "{{ groups['rke2_servers'][0] }}"
   when:
-    - ready_servers | length == 0
+    - rke2_ready_servers | length == 0
 
-# is the ready_servers array is > 0, we assume it's an established cluster and treat all nodes equally (no need for initial server procedure)
+# if rke2_ready_servers is > 0, assume an established cluster and treat all nodes equally
 - name: Save_generated_token.yml
   ansible.builtin.include_tasks: save_generated_token.yml
   vars:
-    token_source_node: "{{ ready_servers[0] }}"
+    token_source_node: "{{ rke2_ready_servers[0] }}"
   when:
-    - ready_servers | length > 0
+    - rke2_ready_servers | length > 0
 
 - name: Start all other rke2 nodes
   ansible.builtin.include_tasks: other_nodes.yml

--- a/roles/rke2/tasks/network_manager_fix.yaml
+++ b/roles/rke2/tasks/network_manager_fix.yaml
@@ -11,7 +11,7 @@
       [keyfile]
       unmanaged-devices=interface-name:cali*;interface-name:flannel*
     create: true
-    mode: 0600
+    mode: '0600'
   when: ansible_facts.services["NetworkManager.service"] is defined
 
 - name: Does rke2-canal.conf exist
@@ -26,7 +26,7 @@
     owner: root
     group: root
   when: rke2_canal_file.stat.exists
-  notify: "Restart {{ service_name }}"
+  notify: "Restart {{ rke2_service_name }}"
 
 - name: Disable service nm-cloud-setup
   ansible.builtin.systemd:
@@ -36,7 +36,7 @@
   when: ansible_facts.services["nm-cloud-setup.service"] is defined
   notify:
     - Reload NetworkManager
-    - "Restart {{ service_name }}"
+    - "Restart {{ rke2_service_name }}"
 
 - name: Disable nm-cloud-setup.timer unit
   ansible.builtin.systemd:
@@ -46,4 +46,4 @@
   when: ansible_facts.services["nm-cloud-setup.service"] is defined
   notify:
     - Reload NetworkManager
-    - "Restart {{ service_name }}"
+    - "Restart {{ rke2_service_name }}"

--- a/roles/rke2/tasks/other_nodes.yml
+++ b/roles/rke2/tasks/other_nodes.yml
@@ -5,7 +5,7 @@
     host: "{{ rke2_kubernetes_api_server_host }}"
     port: "6443"
     state: present
-    timeout: "300"
+    timeout: "{{ rke2_wait_for_api_server_timeout }}"
   changed_when: false
 
 # - name: Include task file add-manifest-addons.yml
@@ -24,4 +24,4 @@
   ansible.builtin.service:
     state: started
     enabled: true
-    name: "{{ service_name }}"
+    name: "{{ rke2_service_name }}"

--- a/roles/rke2/tasks/pre_reqs.yml
+++ b/roles/rke2/tasks/pre_reqs.yml
@@ -10,7 +10,7 @@
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].status != "not-found"
-  notify: "Restart {{ service_name }}"
+  notify: "Restart {{ rke2_service_name }}"
 
 - name: Include task file network_manager_fix.yaml
   ansible.builtin.include_tasks: network_manager_fix.yaml

--- a/roles/rke2/tasks/previous_install.yml
+++ b/roles/rke2/tasks/previous_install.yml
@@ -7,7 +7,6 @@
     - ansible_facts.services["rke2-server.service"] is defined
     - not ansible_facts.services["rke2-server.service"].status == 'disabled'
     - inventory_hostname in groups['rke2_servers']
-    - install_method == "tarball"
 
 - name: Set fact if rke2-server is running
   ansible.builtin.set_fact:
@@ -24,7 +23,6 @@
     - ansible_facts.services["rke2-agent.service"] is defined
     - not ansible_facts.services["rke2-agent.service"].status == 'disabled'
     - inventory_hostname in groups.get('rke2_agents', [])
-    - install_method == "tarball"
 
 - name: Set fact if rke2-agent is running
   ansible.builtin.set_fact:
@@ -34,21 +32,35 @@
     - ansible_facts.services["rke2-agent.service"].state == 'running'
     - inventory_hostname in groups.get('rke2_agents', [])
 
+- name: Build list of rke2 binary paths
+  ansible.builtin.set_fact:
+    rke2_binary_paths:
+      - "{{ rke2_tarball_install_dir }}/bin/rke2"
+      - "/usr/local/bin/rke2"
+      - "/opt/rke2/bin/rke2"
+  when: rke2_install_method == "tarball"
+
 - name: Check for the rke2 binary
   ansible.builtin.stat:
-    path: /usr/local/bin/rke2
-  register: rke2_binary
-  when: install_method == "tarball"
+    path: "{{ item }}"
+  loop: "{{ rke2_binary_paths | unique }}"
+  register: rke2_binary_stats
+  when: rke2_install_method == "tarball"
+
+- name: Select rke2 binary path
+  ansible.builtin.set_fact:
+    rke2_binary_path: "{{ (rke2_binary_stats.results | selectattr('stat.exists', 'equalto', true) | map(attribute='item') | list | first) | default('') }}"
+  when: rke2_install_method == "tarball"
 
 - name: Get current rke2 version if already installed
-  ansible.builtin.shell: set -o pipefail && /usr/local/bin/rke2 -v | awk '$1 ~ /rke2/ { print $3 }'
+  ansible.builtin.shell: set -o pipefail && {{ rke2_binary_path }} -v | awk '$1 ~ /rke2/ { print $3 }'
   register: rke2_installed_version_tmp
   changed_when: false
   args:
     executable: /usr/bin/bash
   when:
-    - install_method == "tarball"
-    - rke2_binary.stat.exists
+    - rke2_install_method == "tarball"
+    - rke2_binary_path | length > 0
   failed_when: >
     (rke2_installed_version_tmp.rc != 141) and
     (rke2_installed_version_tmp.rc != 0)
@@ -57,5 +69,5 @@
   ansible.builtin.set_fact:
     rke2_installed_version: "{{ rke2_installed_version_tmp.stdout }}"
   when:
-    - install_method == "tarball"
-    - rke2_binary.stat.exists
+    - rke2_install_method == "tarball"
+    - rke2_binary_path | length > 0

--- a/roles/rke2/tasks/rpm_install.yml
+++ b/roles/rke2/tasks/rpm_install.yml
@@ -22,15 +22,15 @@
 
 # - name: Debug install
 #   ansible.builtin.debug:
-#     msg: installing {{ service_name }}{{ rke2_version_rpm }}
+#     msg: installing {{ rke2_service_name }}{{ rke2_version_rpm }}
 
 - name: YUM-Based Install
   ansible.builtin.dnf:
-    name: "{{ service_name }}{{ rke2_version_rpm }}"
+    name: "{{ rke2_service_name }}{{ rke2_version_rpm }}"
     state: "{{ rke2_package_state }}"
     allow_downgrade: true
-  register: result
+  register: rke2_rpm_install_result
   retries: 10
-  until: result is succeeded
+  until: rke2_rpm_install_result is succeeded
   delay: 30
-  notify: "Restart {{ service_name }}"
+  notify: "Restart {{ rke2_service_name }}"

--- a/roles/rke2/tasks/save_generated_token.yml
+++ b/roles/rke2/tasks/save_generated_token.yml
@@ -8,22 +8,22 @@
 - name: Read node-token from master
   ansible.builtin.slurp:
     src: /var/lib/rancher/rke2/server/node-token
-  register: node_token
+  register: rke2_node_token
   delegate_to: "{{ token_source_node }}"
 
 - name: Store Master node-token
   ansible.builtin.set_fact:
-    rke2_config_token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
+    rke2_config_token: "{{ rke2_node_token.content | b64decode | regex_replace('\n', '') }}"
   delegate_to: "{{ token_source_node }}"
 
 - name: Set temp fact to store token config line
   ansible.builtin.set_fact:
-    temp_token:
+    rke2_temp_token:
       token: "{{ rke2_config_token }}"
 
-- name: Update host_rke2_config fact to contain server line
+- name: Update host_rke2_config fact to contain server line  # noqa var-naming[no-role-prefix]
   ansible.builtin.set_fact:
-    host_rke2_config: "{{ temp_token | default({}) | ansible.builtin.combine((host_rke2_config | default({})), list_merge='prepend_rp') }}"
+    host_rke2_config: "{{ rke2_temp_token | default({}) | ansible.builtin.combine((host_rke2_config | default({})), list_merge='prepend_rp') }}"
 
 - name: Set temp fact for api host
   ansible.builtin.set_fact:
@@ -33,9 +33,9 @@
 
 - name: Set temp fact to store server config line with custom join server URL
   ansible.builtin.set_fact:
-    temp_host_rke2_config:
+    rke2_temp_host_rke2_config:
       server: "https://{{ rke2_kubernetes_api_server_host }}:9345"
 
-- name: Update host_rke2_config fact to contain server line
+- name: Update host_rke2_config fact to contain server line  # noqa var-naming[no-role-prefix]
   ansible.builtin.set_fact:
-    host_rke2_config: "{{ temp_host_rke2_config | default({}) | ansible.builtin.combine((host_rke2_config | default({})), list_merge='prepend_rp') }}"
+    host_rke2_config: "{{ rke2_temp_host_rke2_config | default({}) | ansible.builtin.combine((host_rke2_config | default({})), list_merge='prepend_rp') }}"

--- a/roles/rke2/tasks/tarball_install.yml
+++ b/roles/rke2/tasks/tarball_install.yml
@@ -4,11 +4,11 @@
     state: directory
     suffix: .rke2-install.XXXXXXXXXX
     path: "{{ tarball_tmp_dir | default(omit) }}"
-  register: temp_dir
+  register: rke2_temp_dir
 
 - name: Set architecture specific variables
   ansible.builtin.set_fact:
-    arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+    rke2_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
 
 - name: Determine if current version differs from what is being installed
   ansible.builtin.set_fact:
@@ -21,7 +21,7 @@
 - name: Send provided tarball from local control machine if available
   ansible.builtin.copy:
     src: "{{ rke2_install_local_tarball_path }}"
-    dest: "{{ temp_dir.path }}/rke2.linux-{{ arch }}.tar.gz"
+    dest: "{{ rke2_temp_dir.path }}/rke2.linux-{{ rke2_arch }}.tar.gz"
     mode: '0644'
   when:
     - rke2_install_local_tarball_path != ""
@@ -29,15 +29,15 @@
 - name: Download Tar from provided URL
   ansible.builtin.get_url:
     url: "{{ rke2_install_tarball_url }}"
-    dest: "{{ temp_dir.path }}/rke2.linux-{{ arch }}.tar.gz"
+    dest: "{{ rke2_temp_dir.path }}/rke2.linux-{{ rke2_arch }}.tar.gz"
     mode: "0644"
   when:
     - rke2_install_tarball_url != ""
 
 - name: Download the tar from github releases
   ansible.builtin.get_url:
-    url: "https://github.com/rancher/rke2/releases/download/{{ rke2_full_version }}/rke2.linux-{{ arch }}.tar.gz"
-    dest: "{{ temp_dir.path }}/rke2.linux-{{ arch }}.tar.gz"
+    url: "https://github.com/rancher/rke2/releases/download/{{ rke2_full_version }}/rke2.linux-{{ rke2_arch }}.tar.gz"
+    dest: "{{ rke2_temp_dir.path }}/rke2.linux-{{ rke2_arch }}.tar.gz"
     mode: "0644"
   when:
     - rke2_install_local_tarball_path == ""
@@ -56,13 +56,13 @@
   block:
     - name: Unarchive tarball into temp location
       ansible.builtin.unarchive:
-        src: "{{ temp_dir.path }}/rke2.linux-{{ arch }}.tar.gz"
-        dest: "{{ temp_dir.path }}"
+        src: "{{ rke2_temp_dir.path }}/rke2.linux-{{ rke2_arch }}.tar.gz"
+        dest: "{{ rke2_temp_dir.path }}"
         remote_src: true
       changed_when: false
 
     - name: Get tarball RKE2 version from temp location
-      ansible.builtin.shell: set -o pipefail && {{ temp_dir.path }}/bin/rke2 -v | awk '$1 ~ /rke2/ { print $3 }'
+      ansible.builtin.shell: set -o pipefail && {{ rke2_temp_dir.path }}/bin/rke2 -v | awk '$1 ~ /rke2/ { print $3 }'
       register: rke2_tarball_version_tmp
       changed_when: false
       args:
@@ -108,7 +108,7 @@
 
     - name: Unarchive rke2 tar
       ansible.builtin.unarchive:
-        src: "{{ temp_dir.path }}/rke2.linux-{{ arch }}.tar.gz"
+        src: "{{ rke2_temp_dir.path }}/rke2.linux-{{ rke2_arch }}.tar.gz"
         dest: "{{ rke2_tarball_install_dir }}"
         remote_src: true
 
@@ -182,6 +182,6 @@
 
 - name: Remove the temp_dir
   ansible.builtin.file:
-    path: "{{ temp_dir.path }}"
+    path: "{{ rke2_temp_dir.path }}"
     state: absent
-  when: temp_dir.path is defined
+  when: rke2_temp_dir.path is defined

--- a/roles/rke2/tasks/utilities.yml
+++ b/roles/rke2/tasks/utilities.yml
@@ -6,7 +6,7 @@
     line: 'PATH=$PATH:/var/lib/rancher/rke2/bin'
     insertafter: EOF
     create: true
-    mode: 0600
+    mode: '0600'
 
 - name: Symlink crictl config to /etc/crictl.yaml
   ansible.builtin.file:

--- a/roles/rke2/tasks/wait_for_rke2.yml
+++ b/roles/rke2/tasks/wait_for_rke2.yml
@@ -5,7 +5,7 @@
 
 - name: Enable service
   ansible.builtin.systemd:
-    name: "{{ service_name }}"
+    name: "{{ rke2_service_name }}"
     state: started
     enabled: true
 
@@ -14,32 +14,34 @@
     host: "{{ rke2_kubernetes_api_server_host }}"
     port: "6443"
     state: present
-    timeout: 300
+    timeout: "{{ rke2_wait_for_api_server_timeout }}"
 
 - name: Wait for kubelet process to be present on host
   ansible.builtin.command: >-
     ps -C kubelet -F -ww --no-headers
-  register: kubelet_check
-  until: kubelet_check.rc == 0
+  register: rke2_kubelet_check
+  until: rke2_kubelet_check.rc == 0
   retries: 20
   delay: 10
   changed_when: false
 
 - name: Extract the hostname-override parameter from the kubelet process
   ansible.builtin.set_fact:
-    kubelet_hostname: "{{ kubelet_check.stdout | regex_search('\\s--hostname-override=([^\\s]+)', '\\1') }}"
+    rke2_kubelet_hostname: "{{ rke2_kubelet_check.stdout | regex_search('\\s--hostname-override=([^\\s]+)', '\\1') | default('', true) }}"
   when:
     - inventory_hostname in groups['rke2_servers']
 
 - name: Wait for node to show Ready status
   ansible.builtin.command: >-
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
-    --server https://127.0.0.1:6443 get no {{ kubelet_hostname[0] }}
+    --server https://127.0.0.1:6443 get node "{{ rke2_kubelet_hostname }}"
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-  register: status_result
-  until: status_result.stdout.find("True") != -1
+  register: rke2_status_result
+  until: rke2_status_result.stdout.find("True") != -1
   retries: 20
   delay: 10
   changed_when: false
   when:
     - inventory_hostname in groups['rke2_servers']
+    - rke2_kubelet_hostname is defined
+    - rke2_kubelet_hostname | length > 0

--- a/roles/testing/tasks/basic_tests.yml
+++ b/roles/testing/tasks/basic_tests.yml
@@ -3,17 +3,17 @@
 - name: "Is the rke2/config.yaml in place?"
   ansible.builtin.stat:
     path: /etc/rancher/rke2/config.yaml
-  register: test_rke2_config_file
+  register: testing_rke2_config_file
 
 - name: "Is 'selinux: true' in rke2/config.yaml?"
   ansible.builtin.lineinfile:
     path: /etc/rancher/rke2/config.yaml
     line: "selinux: true"
   check_mode: true
-  register: test_is_selinux_true
+  register: testing_is_selinux_true
 
 - name: Assertions
   ansible.builtin.assert:
     that:
-      - test_rke2_config_file.stat.exists
-      - not test_is_selinux_true.failed
+      - testing_rke2_config_file.stat.exists
+      - not testing_is_selinux_true.failed

--- a/roles/testing/tasks/kubectl_basic.yml
+++ b/roles/testing/tasks/kubectl_basic.yml
@@ -4,15 +4,15 @@
 - name: Ensure kubelet process is present on host
   ansible.builtin.command: >-
     ps -C kubelet -F -ww --no-headers
-  register: kubelet_check
-  until: kubelet_check.rc == 0
+  register: testing_kubelet_check
+  until: testing_kubelet_check.rc == 0
   retries: 20
   delay: 10
   changed_when: false
 
 - name: Extract the hostname-override parameter from the kubelet process  # noqa jinja[spacing]
   ansible.builtin.set_fact:
-    kubelet_hostname_override_parameter: "{{ kubelet_check.stdout |\
+    testing_kubelet_hostname_override_parameter: "{{ testing_kubelet_check.stdout |\
       regex_search('\\s--hostname-override=((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
       '\\1') }}"
   changed_when: false
@@ -20,16 +20,16 @@
 - name: Are all nodes in Ready state?
   ansible.builtin.command: >-
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
-    --server https://127.0.0.1:6443 get no {{ kubelet_hostname_override_parameter[0] }}
+    --server https://127.0.0.1:6443 get no {{ testing_kubelet_hostname_override_parameter[0] }}
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-  until: status_result.stdout.find("True") != -1
+  until: testing_status_result.stdout.find("True") != -1
   retries: 20
   delay: 10
-  register: status_result
+  register: testing_status_result
   delegate_to: "{{ groups['rke2_servers'][0] }}"
   changed_when: false
 
 - name: Assertions
   ansible.builtin.assert:
     that:
-      - "'True' in status_result.stdout"
+      - "'True' in testing_status_result.stdout"

--- a/roles/testing/tasks/manifest_test.yml
+++ b/roles/testing/tasks/manifest_test.yml
@@ -21,11 +21,11 @@
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
     get pod automated-testing-pod
     -o jsonpath='{.status.phase}'
-  register: status_result
+  register: testing_status_result
   delegate_to: "{{ groups['rke2_servers'][0] }}"
   changed_when: false
 
 - name: Assertions
   ansible.builtin.assert:
     that:
-      - "'Running' in status_result.stdout"
+      - "'Running' in testing_status_result.stdout"

--- a/roles/testing/tasks/troubleshooting.yml
+++ b/roles/testing/tasks/troubleshooting.yml
@@ -4,46 +4,43 @@
   ansible.builtin.command: >-
     journalctl -e --lines 200 --no-pager
   changed_when: false
-  register: command_output
+  register: testing_command_output
   tags:
     - troubleshooting
-  ignore_errors: true
+  failed_when: false
 
 - name: Show journalctl -e
   ansible.builtin.debug:
-    var: command_output.stdout_lines
+    var: testing_command_output.stdout_lines
   tags:
     - troubleshooting
-  ignore_errors: true
 
 - name: Show journalctl -ue rke2-server
   ansible.builtin.command: >-
     journalctl -eu rke2-server --lines 200 --no-pager
   changed_when: false
-  register: command_output
+  register: testing_command_output
   tags:
     - troubleshooting
-  ignore_errors: true
+  failed_when: false
 
 - name: Show journalctl -ue rke2-server
   ansible.builtin.debug:
-    var: command_output.stdout_lines
+    var: testing_command_output.stdout_lines
   tags:
     - troubleshooting
-  ignore_errors: true
 
 - name: Show rke2 config file
   ansible.builtin.command: >-
     cat /etc/rancher/rke2/config.yaml
   changed_when: false
-  register: command_output
+  register: testing_command_output
   tags:
     - troubleshooting
-  ignore_errors: true
+  failed_when: false
 
 - name: Show rke2 config file
   ansible.builtin.debug:
-    var: command_output.stdout_lines
+    var: testing_command_output.stdout_lines
   tags:
     - troubleshooting
-  ignore_errors: true


### PR DESCRIPTION
## What this PR does
- Fix readiness detection so it fails correctly and uses the full node name.
- Make API/kubelet wait timeouts configurable for slower hosts.
- Detect prior installs in /opt and custom tarball paths.
- Normalize role variable names to satisfy ansible-lint.
- Add Galaxy publish workflow, SLES CI, and upgrade coverage.
- Document local Molecule usage.

## Why
The current readiness logic could mis-detect nodes and continue on failure. Slow machines also needed longer waits. CI and local testing docs were missing a few pieces.

## Issues
Fixes #279
Fixes #236
Fixes #239
Fixes #208
Fixes #270
Fixes #273
Fixes #78

## Testing
- ansible-lint ./roles
- yamllint .
