### PR TITLE
Restrict token_source_node to ansible_play_batch

### DIFF
--- a/roles/rke2/tasks/main.yml
+++ b/roles/rke2/tasks/main.yml
@@ -99,7 +99,7 @@
 - name: Save_generated_token.yml
   ansible.builtin.include_tasks: save_generated_token.yml
   vars:
-    token_source_node: "{{ groups['rke2_servers'][0] }}"
+    token_source_node: "{{ groups['rke2_servers'] | intersect(ansible_play_batch) | first }}"
   when:
     - ready_servers is not defined or ready_servers | length == 0
 


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it

In our use case, we want to be able to deploy multiple separate clusters using this role. Without this change, a node from cluster A may be affected by the deployment of cluster B.

In our setup, all of the nodes in all clusters are in the rke2_servers group, but each cluster has its own separate group as well. When we deploy a cluster, we just restrict the playbook to that cluster's group. Without this change, using this role in such a way is impossible.

Prior to this change, the rke2 role saved the generated token to the first node in the rke2_servers group. This change saves the token to the first node in the rke2_servers group that is *also* in the play batch, i.e. the nodes that are targeted by the current play.

## Which issue(s) this PR fixes:

None.

## Special notes for your reviewer:

This may not be the kind of thing you want to merge, and if that's the case I totally understand, but it does help us use this role and I can't think of a way it would affect anyone negatively. Thanks!

## Testing

I have tested deploying 3 and 5 node clusters using this role on Rocky 9.6 VMs. Deploying a single cluster works as before, but deploying a second separate cluster in the same inventory is now possible.

## Release Notes

```release-note
NONE
```

