### PR TITLE
option to leave firewalld alone

### DIFF
--- a/roles/rke2/defaults/main.yml
+++ b/roles/rke2/defaults/main.yml
@@ -105,6 +105,9 @@ rke2_upgrade: true
 ## Value for how many Agent nodes can have their service restarted at time when a config change is made
 rke2_agent_service_restart_throttle: 1
 
+## Various CNIs and RKE2 both recommend disabling firewalld. Set to true if you want this playbook to leave the state of firewalld untouched. 
+rke2_ignore_firewalld: false
+
 # Should not be changed:
 rke2_metrics_running: false
 rke2_node_ready: "false"

--- a/roles/rke2/defaults/main.yml
+++ b/roles/rke2/defaults/main.yml
@@ -105,7 +105,7 @@ rke2_upgrade: true
 ## Value for how many Agent nodes can have their service restarted at time when a config change is made
 rke2_agent_service_restart_throttle: 1
 
-## Various CNIs and RKE2 both recommend disabling firewalld. Set to true if you want this playbook to leave the state of firewalld untouched. 
+## Various CNIs and RKE2 both recommend disabling firewalld. Set to true if you want this playbook to leave the state of firewalld untouched.
 rke2_ignore_firewalld: false
 
 # Should not be changed:

--- a/roles/rke2/tasks/pre_reqs.yml
+++ b/roles/rke2/tasks/pre_reqs.yml
@@ -10,6 +10,7 @@
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].status != "not-found"
+    - not rke2_ignore_firewalld
   notify: "Restart {{ service_name }}"
   tags: ["setup-os"]
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [X] feature

## What this PR does / why we need it:

Allows users to use firewalld if they want.

## Which issue(s) this PR fixes:

Fixes #337 

## Testing

Set `rke2_ignore_firewalld: true` and firewalld should remain untouched.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Add rke2_ignore_firewalld option to prevent playbook from disabling firewalld
```

