### PR TITLE
Revert pod security admission config file name change

### DIFF
--- a/roles/rke2/tasks/configure_rke2.yml
+++ b/roles/rke2/tasks/configure_rke2.yml
@@ -40,7 +40,7 @@
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
     file_contents: "{{ lookup('file', rke2_pod_security_admission_config_file_path) }}"
-    file_destination: "/etc/rancher/rke2/rke2-pss.yaml"
+    file_destination: "/etc/rancher/rke2/pod-security-admission-config.yaml"
     file_description: "pod security admission config"
     file_path: "{{ rke2_pod_security_admission_config_file_path }}"
   when:


### PR DESCRIPTION
## What type of PR is this?
- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:
Revert the file name of the pod security admission config file back to what it was in v2.0.0.  The RKE2 server process always overwrites the file named rke2-pss.yaml to it's default values. The [rke2 docs](https://docs.rke2.io/security/pod_security_standards) make a vague reference that this file is auto-generated:
> RKE2 will put this configuration file at /etc/rancher/rke2/rke2-pss.yaml, the content of the configuration file varies according to the cis mode which you started rke2.

They then go on to describe how you can specify your own file.

## Which issue(s) this PR fixes:
Fixes #341 

## Testing
I observed the file being overwritten by doing a `cat` of the file after the ansible copied the file.  Before the rke2-server is restarted, the file contains the custom content. As soon as rke2-server restarts, the file is overwritten to it's default values.

## Release Notes
```release-note
Revert pod security admission config file name change made in #340 back to `pod-security-admission-config.yaml`
```

