### PR TITLE
Mikechau datadir

### DIFF
--- a/roles/rke2/tasks/check_datadir.yml
+++ b/roles/rke2/tasks/check_datadir.yml
@@ -1,26 +1,9 @@
 ---
-- name: Set data-dir from cluster config var or use default
+- name: Set rke2_data_dir
   ansible.builtin.set_fact:
-    rke2_data_dir: "{{ (cluster_rke2_config | from_yaml).get('data-dir') }}"
-  when:
-    - cluster_rke2_config | length > 0
-    - "'data-dir' in cluster_rke2_config"
-
-- name: Set data-dir from group config var or use default
-  ansible.builtin.set_fact:
-    rke2_data_dir: "{{ (group_rke2_config | from_yaml).get('data-dir') }}"
-  when:
-    - group_rke2_config | length > 0
-    - "'data-dir' in group_rke2_config"
-
-- name: Set data-dir from host config var or use default
-  ansible.builtin.set_fact:
-    rke2_data_dir: "{{ (host_rke2_config | from_yaml).get('data-dir') }}"
-  when:
-    - host_rke2_config | length > 0
-    - "'data-dir' in host_rke2_config"
-
-- name: Set data-dir to default path
-  ansible.builtin.set_fact:
-    rke2_data_dir: '/var/lib/rancher/rke2'
-  when: rke2_data_dir is not defined or not rke2_data_dir
+    rke2_data_dir: >-
+      {{
+        (cluster_rke2_config | from_yaml).get('data-dir') | default(
+        (group_rke2_config | from_yaml).get('data-dir')) | default(
+        (host_rke2_config | from_yaml).get('data-dir')) | default('/var/lib/rancher/rke2')
+      }}

--- a/roles/rke2/tasks/check_datadir.yml
+++ b/roles/rke2/tasks/check_datadir.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     rke2_data_dir: >-
       {{
-        (cluster_rke2_config | from_yaml).get('data-dir') | default(
-        (group_rke2_config | from_yaml).get('data-dir')) | default(
-        (host_rke2_config | from_yaml).get('data-dir')) | default('/var/lib/rancher/rke2')
+        host_rke2_config.get('data-dir') | default(
+        group_rke2_config.get('data-dir'), boolean=True) | default(
+        cluster_rke2_config.get('data-dir'), boolean=True) | default('/var/lib/rancher/rke2', boolean=True)
       }}

--- a/roles/rke2/tasks/check_datadir.yml
+++ b/roles/rke2/tasks/check_datadir.yml
@@ -1,18 +1,24 @@
 ---
 - name: Set data-dir from cluster config var or use default
   ansible.builtin.set_fact:
-    rke2_data_dir: "{{ (cluster_rke2_config | from_yaml).get('data-dir', '/var/lib/rancher/rke2') }}"
-  when: cluster_rke2_config | length > 0
+    rke2_data_dir: "{{ (cluster_rke2_config | from_yaml).get('data-dir') }}"
+  when:
+    - cluster_rke2_config | length > 0
+    - "'data-dir' in cluster_rke2_config"
 
 - name: Set data-dir from group config var or use default
   ansible.builtin.set_fact:
-    rke2_data_dir: "{{ (group_rke2_config | from_yaml).get('data-dir', '/var/lib/rancher/rke2') }}"
-  when: group_rke2_config | length > 0
+    rke2_data_dir: "{{ (group_rke2_config | from_yaml).get('data-dir') }}"
+  when:
+    - group_rke2_config | length > 0
+    - "'data-dir' in group_rke2_config"
 
 - name: Set data-dir from host config var or use default
   ansible.builtin.set_fact:
-    rke2_data_dir: "{{ (host_rke2_config | from_yaml).get('data-dir', '/var/lib/rancher/rke2') }}"
-  when: host_rke2_config | length > 0
+    rke2_data_dir: "{{ (host_rke2_config | from_yaml).get('data-dir') }}"
+  when:
+    - host_rke2_config | length > 0
+    - "'data-dir' in host_rke2_config"
 
 - name: Set data-dir to default path
   ansible.builtin.set_fact:

--- a/roles/rke2/tasks/check_datadir.yml
+++ b/roles/rke2/tasks/check_datadir.yml
@@ -23,4 +23,4 @@
 - name: Set data-dir to default path
   ansible.builtin.set_fact:
     rke2_data_dir: '/var/lib/rancher/rke2'
-  when: rke2_data_dir is not defined
+  when: rke2_data_dir is not defined or not rke2_data_dir


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [X] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

The rke2_data_dir ends up being always replaced by the host_rke2_config default if host_rke2_config["data-dir"] is not set.

This change checks to see if data-dir is defined in cluster_rke2_config, group_rke2_config and host_rke2_config, before setting rke2_data_dir. If none of them have data-dir, it will fallback to setting rke2_data_dir to /var/lib/rancher/rke2.

## Special notes for your reviewer:

There's probably a more cleaner way to do this like instead of checking for data-dir individually we could combine these vars to create the full rke2_config:

- name: Build merged rke2_config
  ansible.builtin.set_fact:
    rke2_config: >-
      {{
          (cluster_rke2_config | default({}))
          | combine(group_rke2_config | default({}))
          | combine(host_rke2_config | default({}))
      }}

- name: Set rke2_data_dir
  ansible.builtin.set_fact:
    rke2_data_dir: "{{ rke2_config.get('data-dir', '/var/lib/rancher/rke2') }}"

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## Release Notes

```release-note
updates to data-dir logic

```

